### PR TITLE
Issue-1759 Fixing NLP for invalid cookie value

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/Response.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Response.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import static java.util.Objects.nonNull;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.graalvm.polyglot.Value;
@@ -122,7 +123,10 @@ public class Response implements ProxyObject {
         Map<String, Map> map = new HashMap();
         for (String value : values) {
             Cookie cookie = ClientCookieDecoder.STRICT.decode(value);
-            map.put(cookie.name(), Cookies.toMap(cookie));
+            // skipping cookie containing invalid char
+            if(nonNull(cookie)) {
+            	map.put(cookie.name(), Cookies.toMap(cookie));
+            }
         }
         return map;
     }

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/MockRunner.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/MockRunner.java
@@ -60,4 +60,8 @@ class MockRunner {
         run("upload.feature");
     }    
 
+    @Test
+    void testInvalidCookie() {
+    	run("invalid-cookie.feature");
+    }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/_mock.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/_mock.feature
@@ -116,3 +116,6 @@ Scenario: pathMatches('/v1/html')
         </body>
     </html>
     """
+
+Scenario: pathMatches('/v1/invalid-cookie')
+    * def responseHeaders = { 'Set-Cookie': 'detectedTimeZoneId=FLE Standard Time' }    

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/invalid-cookie.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/invalid-cookie.feature
@@ -1,0 +1,10 @@
+Feature:
+
+Background:
+* url mockServerUrl
+
+  Scenario:
+    * path 'invalid-cookie';
+    * method get
+    * status 200
+

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/invalid-cookie.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/invalid-cookie.feature
@@ -7,4 +7,3 @@ Background:
     * path 'invalid-cookie';
     * method get
     * status 200
-


### PR DESCRIPTION
### If An invalid header is set a NLP exception is thrown.
Karate internally uses ```ClientCookieDecoder.STRICT.decode(value)``` to parse the cookies and whenever an Invalid Cookie is set it return null and code fails with NLP while calling ```cookie.name()```

Before the change it fails with NLP:

<img width="1211" alt="Screenshot 2021-10-02 at 2 48 14 PM" src="https://user-images.githubusercontent.com/16278936/135713161-533efb3b-a46b-4f8d-90c1-487e1a6421a1.png">

- Relevant Issues : https://github.com/intuit/karate/issues/1759
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
