### PR TITLE
Regression test for #1786

### DIFF
--- a/karate-e2e-tests/src/test/java/driver/03.feature
+++ b/karate-e2e-tests/src/test/java/driver/03.feature
@@ -16,3 +16,14 @@ Scenario:
 * match script('#helloDiv', "_.style['color']") == 'red'
 * match script('.styled-div', "function(e){ return getComputedStyle(e)['font-size'] }") == '30px'
 * match script('.styled-div', "_ => getComputedStyle(_)['font-size']") == '30px'
+
+# Regression test for https://github.com/karatelabs/karate/issues/1786
+# Tests that Karate can handle console logging -- we can't assert it is working, but we can check that it doesn't crash devtools connection
+# Expect Karate to log "[console] testing"
+* script("console.log('testing')")
+
+# Expect Karate to log "[console] true"
+* script("console.log(true)")
+
+# Expect Karate to log "[console] 1"
+* script("console.log(1)")


### PR DESCRIPTION
### Description

- Relevant Issues : #1786, https://github.com/karatelabs/karate/projects/3#card-70112710
- Relevant PRs : #1787 
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Regression test of fix for #1786. Tested locally by running `LocalSingleRunner` on the `00.feature` file, which calls the modified `03.feature` file. Tested only in Chrome.

There is no way to actually assert the logging output that I can see. I did not feel like it would be a worthwhile generic feature to provide a way in the driver to capture console output for assertions as `console.log` is not a user-visible experience, and a "hack" way to do it looked hard considering the `Logger` is a class, not interface and there's no exposure to change the logger of `DevToolsDriver`. Hence, the test is considered passing if the commands do not fail and the test proceeds, with full verification possible manually only, with comments providing expected output.