### PR TITLE
Issue #1794 - Fix for tags not being honored in karate-gatling

### DIFF
--- a/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
+++ b/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
@@ -94,7 +94,7 @@ class KarateFeatureAction(val name: String, val tags: Seq[String], val protocol:
     runner.callOnceCache(protocol.callOnceCache)
     runner.tags(tags.asJava)
 
-    Runner.callAsync(protocol.runner, name, callArg, perfHook)
+    Runner.callAsync(runner, name, callArg, perfHook)
 
   }
 


### PR DESCRIPTION
### Description

- Relevant Issues : #1794 
- Relevant PRs : None
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

`KarateFeatureAction` makes a copy of `protocol.runner` and then sets the tags on that copy.  In order to honor the tags, we need to pass the copy to `Runner.callAsync` rather than the original `protocol.runner`.

I have validated that the fix works by following the steps I documented in #1794.