### PR TITLE
Update Chrome and Edge DevToolsDriver class to check for 64bit executable path or else default to 32bit executable path

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/chrome/Chrome.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/chrome/Chrome.java
@@ -32,6 +32,9 @@ import com.intuit.karate.shell.Command;
 import com.intuit.karate.driver.DevToolsDriver;
 import com.intuit.karate.driver.DriverOptions;
 import com.intuit.karate.http.Response;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +49,9 @@ public class Chrome extends DevToolsDriver {
     public static final String DRIVER_TYPE = "chrome";
 
     public static final String DEFAULT_PATH_MAC = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
-    public static final String DEFAULT_PATH_WIN = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe";
+    public static final String DEFAULT_PATH_WIN32 = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe";
+    public static final String DEFAULT_PATH_WIN64 = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+    public static final String DEFAULT_PATH_WIN = Files.isRegularFile(Paths.get(DEFAULT_PATH_WIN64)) && Files.isReadable(Paths.get(DEFAULT_PATH_WIN64)) ? DEFAULT_PATH_WIN64 : DEFAULT_PATH_WIN32;
     public static final String DEFAULT_PATH_LINUX = "/usr/bin/google-chrome";
 
     public Chrome(DriverOptions options, Command command, String webSocketUrl) {

--- a/karate-core/src/main/java/com/intuit/karate/driver/microsoft/EdgeChromium.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/microsoft/EdgeChromium.java
@@ -33,6 +33,8 @@ import com.intuit.karate.driver.DriverOptions;
 import com.intuit.karate.http.Response;
 import com.intuit.karate.shell.Command;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -47,7 +49,9 @@ public class EdgeChromium extends DevToolsDriver {
     public static final String DRIVER_TYPE = "msedge";
 
     public static final String DEFAULT_PATH_MAC = "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge";
-    public static final String DEFAULT_PATH_WIN = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
+    public static final String DEFAULT_PATH_WIN32 = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
+    public static final String DEFAULT_PATH_WIN64 = "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe";
+    public static final String DEFAULT_PATH_WIN = Files.isRegularFile(Paths.get(DEFAULT_PATH_WIN64)) && Files.isReadable(Paths.get(DEFAULT_PATH_WIN64)) ? DEFAULT_PATH_WIN64 : DEFAULT_PATH_WIN32;
     public static final String DEFAULT_PATH_LINUX = "/dev/null";
 
     public EdgeChromium(DriverOptions options, Command command, String webSocketUrl) {


### PR DESCRIPTION
- Added code to check for 64bit path of chrome.exe \ msedge.exe else defaulting to 32bit equivalent path on Windows OS

### Description

- Relevant Issues : https://github.com/karatelabs/karate/issues/1800
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
