### PR TITLE
Exposes DapServer.exitAfterDisconnect as a command line option.

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -120,12 +120,15 @@ public class Main implements Callable<Void> {
     @Option(names = {"-C", "--clean"}, description = "clean output directory")
     boolean clean;
 
+    @Option(names = {"-B", "--backup-reportdir"}, defaultValue = "true", arity = "0..1", fallbackValue = "true", description = "backup report directory before running tests")
+    boolean backupReportDir = true;
+
     @Option(names = {"-d", "--debug"}, arity = "0..1", defaultValue = "-1", fallbackValue = "0",
             description = "debug mode (optional port else dynamically chosen)")
     int debugPort;
 
-    @Option(names = {"--keep-debug-server"}, defaultValue = "false", arity = "0..1", fallbackValue = "true", description = "keep debug server open for connections after disconnect")
-    boolean keepDebugServerAfterDisconnect;
+    @Option(names = {"--debug-keepalive"}, defaultValue = "false", arity = "0..1", fallbackValue = "true", description = "keep debug server open for connections after disconnect")
+    boolean keepDebugServerAlive;
 
     @Option(names = {"-D", "--dryrun"}, description = "dry run, generate html reports only")
     boolean dryRun;
@@ -326,7 +329,7 @@ public class Main implements Callable<Void> {
             return null;
         }
         if (debugPort != -1) {
-            DapServer server = new DapServer(debugPort, !keepDebugServerAfterDisconnect);
+            DapServer server = new DapServer(debugPort, !keepDebugServerAlive);
             server.waitSync();
             return null;
         }
@@ -336,6 +339,7 @@ public class Main implements Callable<Void> {
                     .karateEnv(env)
                     .workingDir(workingDir)
                     .buildDir(output)
+                    .backupReportDir(backupReportDir)
                     .configDir(configDir)
                     .outputHtmlReport(isOutputHtmlReport())
                     .outputCucumberJson(isOutputCucumberJson())

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServer.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServer.java
@@ -49,14 +49,14 @@ public class DapServer {
     private final Channel channel;
     private final String host;
     private final int port;
-    private final boolean exitAfterDisconnect;
+    private final boolean keepAlive;
     
     public int getPort() {
         return port;
     }
 
-    public boolean exitAfterDisconnect() {
-        return exitAfterDisconnect;
+    public boolean isKeepAlive() {
+        return keepAlive;
     }
 
     public void waitSync() {
@@ -78,10 +78,10 @@ public class DapServer {
         this(requestedPort, true);
     }
 
-    public DapServer(int requestedPort, boolean exitAfterDisconnect) {
+    public DapServer(int requestedPort, boolean keepAlive) {
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
-        this.exitAfterDisconnect = exitAfterDisconnect;
+        this.keepAlive = keepAlive;
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
@@ -469,7 +469,7 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
         channel.eventLoop().execute(()
                 -> channel.writeAndFlush(event("exited")
                         .body("exitCode", 0)));
-        if (server.exitAfterDisconnect()) {
+        if (server.isKeepAlive()) {
             server.stop();
             System.exit(0);
         } else {


### PR DESCRIPTION
### Description

DapServer already has a feature to keep debuging session open. 
This PR exposes DapServer.exitAfterDisconnect as a command line option.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
