### PR TITLE
Fix bug that prevents from disabling the proxy

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Config.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Config.java
@@ -276,7 +276,7 @@ public class Config {
                 readTimeout = value.getAsInt();
                 return true;
             case "proxy":
-                if (value == null) {
+                if (value.isNull()) {
                     proxyUri = null;
                 } else if (value.isString()) {
                     proxyUri = value.getAsString();


### PR DESCRIPTION
### Description

- Relevant Issues : When trying to deactivate the proxy by calling `karate.configure('proxy', null)`, the following error occurs: `org.graalvm.polyglot.PolyglotException: Cannot invoke "java.util.Map.get(java.lang.Object)" because "map" is null`.
This is because in the code, the varible type itself is checked if null -> `if (value == null)`. Since that is never the case, the value is by default eveluated as a map, which results in the error. 
Instead, it needs to be checked if the type within the Variable wrapper has been set to NULL. -> `if (value.isNull())`.

- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
