### PR TITLE
Allow multiple features in cli separated by ';'

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -63,7 +63,7 @@ public class Main implements Callable<Void> {
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "display this help message")
     boolean help;
 
-    @Parameters(split = "$", description = "one or more tests (features) or search-paths to run")
+    @Parameters(split = "($|,)", description = "one or more tests (features) or search-paths to run")
     List<String> paths;
 
     @Option(names = {"-m", "--mock", "--mocks"}, split = ",", description = "one or more mock server files")

--- a/karate-core/src/test/java/com/intuit/karate/IdeMainRunner.java
+++ b/karate-core/src/test/java/com/intuit/karate/IdeMainRunner.java
@@ -13,6 +13,11 @@ class IdeMainRunner {
     void testCli() {
         IdeMain.main(new String[]{"-t", "~@skipme", "-T", "2", "classpath:com/intuit/karate/core/runner/multi-scenario.feature"});
     }
+
+    @Test
+    void testCliMultipleFeatures() {
+        IdeMain.main(new String[]{"-t", "~@skipme", "-T", "2", "classpath:com/intuit/karate/core/runner/scenario.feature,classpath:com/intuit/karate/core/runner/multi-scenario.feature"});
+    }
     
     @Test
     void testMain() {

--- a/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
@@ -43,6 +43,16 @@ class IdeMainTest {
     }
 
     @Test
+    void testMutlipleFeaturesArgs() {
+        Main options = IdeMain.parseStringArgs(new String[]{"--tags", "~@skipme", "foo.feature,bar.feature"});
+        assertEquals(2, options.paths.size());
+        assertEquals("foo.feature", options.paths.get(0));
+        assertEquals("bar.feature", options.paths.get(1));
+        assertEquals("~@skipme", options.tags.get(0));
+        assertNull(options.name);
+    }
+
+    @Test
     void testParsingCommandLine() {
         Main options = IdeMain.parseIdeCommandLine(INTELLIJ1);
         assertEquals("^get users and then get first by id$", options.name);


### PR DESCRIPTION
### Description

Currently Main 'paths' allows multiple features passed as parameters but split by `$` which is an EOL and makes it very dificcult to pass mutiple on the command line.

WIth this PR both EOL and `,` characters (same as mocks) will be valid for spliting path parametes

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
