### PR TITLE
Allow matching Status as variable or expression

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Actions.java
+++ b/karate-core/src/main/java/com/intuit/karate/Actions.java
@@ -132,7 +132,7 @@ public interface Actions {
 
     void soapAction(String action);
 
-    void status(int status);
+    void status(String status);
 
     void table(String name, List<Map<String, String>> table);
 

--- a/karate-core/src/main/java/com/intuit/karate/ScenarioActions.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScenarioActions.java
@@ -309,8 +309,8 @@ public class ScenarioActions implements Actions {
     }
 
     @Override
-    @When("^status\\h+(\\d+)")
-    public void status(int status) {
+    @When("^status\\h+(.+)")
+    public void status(String status) {
         engine.status(status);
     }
 

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -677,7 +677,8 @@ public class ScenarioEngine {
         }
     }
 
-    public void status(int status) {
+    public void status(String statusExpression) {
+        int status = evalJs(statusExpression).getAsInt();
         if (status != response.getStatus()) {
             // make sure log masking is applied
             String message = HttpLogger.getStatusFailureMessage(status, config, request, response);

--- a/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
@@ -113,7 +113,7 @@ public class StepRuntimeTest {
                 "match"),
                 Arguments.of(com.intuit.karate.ScenarioActions.class.getMethod("assertTrue", String.class),
                 "assert"),
-                Arguments.of(com.intuit.karate.ScenarioActions.class.getMethod("status", int.class),
+                Arguments.of(com.intuit.karate.ScenarioActions.class.getMethod("status", String.class),
                 "status"),
                 Arguments.of(com.intuit.karate.ScenarioActions.class.getMethod("eval", String.class),
                 "eval"),

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/MockRunner.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/MockRunner.java
@@ -64,4 +64,9 @@ class MockRunner {
     void testInvalidCookie() {
     	run("invalid-cookie.feature");
     }
+
+    @Test
+    void testStatusExpression() {
+        run("hello-world-status.feature");
+    }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/hello-world-status.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/hello-world-status.feature
@@ -1,0 +1,21 @@
+Feature: simple example of a karate test
+
+Background:
+# to test that expressions also work for the method keyword
+* def postMethod = 'post'
+* def getMethod = 'get'
+* def status201 = 201
+* def status200 = 200
+
+Scenario: create and retrieve a cat
+
+Given url mockServerUrl + 'cats'
+And request { name: 'Billie' }
+When method postMethod
+Then status status201
+And match response == { id: '#ignore', name: 'Billie' }
+# And assert responseTime < 1000
+
+Given path response.id
+When method getMethod
+Then status status200


### PR DESCRIPTION
### Description

Karate "status" step only allows constant numeric values, not variables or expressions.

When reusing karate features for different responses and the status being and argument or variable, matching the numeric value gives a less friendly error message than using the built-in "status" step

Examples:

```
* match responseStatus == expectedStatusCode
match failed: EQUALS
  $ | not equal (NUMBER:NUMBER)
  200
  400
```

vs

```
Then status status200variable
status code was: 201, expected: 200, response time in milliseconds: 491
```

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
