### PR TITLE
Fix Set related flaky tests

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -417,7 +418,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder cookie(Cookie cookie) {
         if (cookies == null) {
-            cookies = new HashSet<>();
+            cookies = new LinkedHashSet<>();
         }
         cookies.add(cookie);
         return this;


### PR DESCRIPTION
### Description
The test
```
com.intuit.karate.core.KarateHttpMockHandlerTest.testMultipleCookies
```
failed under environment [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detect flakiness under non-deterministic data structure usages. 

The potential problem is that Object `cookie` is a member of `HashSet` ([reference](https://github.com/karatelabs/karate/blob/master/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java#L420)), whose order is not guaranteed during iteration on different environment.

**Quote from [Oracle Java 8 Doc](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html)**
>  It makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time. This class permits the null element.

- Relevant Issues : potential flaky tests due to non-deterministic cookie object
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation


### Reproduce
```sh
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -pl karate-core -Dtest=intuit.karate.core.KarateHttpMockHandlerTest#testMultipleCookies 
```

### Proposal
Changed to use LinkedHashSet which provides predictable orders. Please let me know if you have any question!
