### PR TITLE
Update DockerTarget.java

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/DockerTarget.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DockerTarget.java
@@ -155,7 +155,7 @@ public class DockerTarget implements Target {
         String dockerPort = Command.execLine((File)null, "docker port " + containerId + " 9222/tcp");
         Pattern portPattern = Pattern.compile("(\\d+?\\.){3}\\d:(\\d+)");
         Matcher matcher = portPattern.matcher(dockerPort);
-        if (matcher.matches()) {
+        if (matcher.find()) {
             try {
                 return Integer.parseInt(matcher.group(2));
             } catch (NumberFormatException e) {


### PR DESCRIPTION
Update getContainerPort method

### Description

Using `matcher.matches()` method gives not results. Changing implementation to `matcher.find()`

- Relevant Issues :  #1857
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
