### PR TITLE
Issue #1834 - Fix for High Severity CVE's in karate-core

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.linecorp.armeria</groupId>
             <artifactId>armeria</artifactId>
-            <version>1.13.2</version>
+            <version>1.13.4</version>
         </dependency>              
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,18 @@
     <build>       
         <plugins>
             <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>6.5.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.version}</version>


### PR DESCRIPTION
### Description

- Relevant Issues : #1834
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Another high-severity CVE was found in `armeria` so I upgraded from `1.13.2` to `1.13.4`.

I added `dependency-check-maven` to the root POM so that dependencies all modules will be checked for CVE's.  When doing a build, the check will run during the `verify` phase, and the aggregate report will be written to `target/dependency-check-report.html`.

The dependency check plugin has an option to fail the build if any high-severity CVE's are found.  I decided to turn that option off as I believe it will make the build too brittle.  This means that a manual review of `target/dependency-check-report.html` is required to see if any vulnerabilities are present.

The report currently shows high-severity CVS's in `karate-gatling`, `karate-demo`, and `karate-robot`.  While it would be nice to address those in the future, I believe we can leave them for now since those modules are not shaded.