### PR TITLE
Update XmlUtils.java

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -121,6 +121,7 @@ public class XmlUtils {
 
     public static Document toXmlDoc(String xml) {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
         try {
             DocumentBuilder builder = factory.newDocumentBuilder();
             DtdEntityResolver dtdEntityResolver = new DtdEntityResolver();


### PR DESCRIPTION
Ref. this discussion thread :
https://stackoverflow.com/questions/70569320/why-is-xmlns-added-by-karate
Setting 
factory.setNamespaceAware(true);
will fix the issue with DocumentBuilder  adding empty xmlns

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
