### PR TITLE
callSingle update

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioBridge.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioBridge.java
@@ -182,21 +182,17 @@ public class ScenarioBridge implements PerfContext, EventContext {
     public Object callSingle(String fileName, Value arg) throws Exception {
         ScenarioEngine engine = getEngine();
         final Map<String, Object> CACHE = engine.runtime.featureRuntime.suite.callSingleCache;
-        if (CACHE.containsKey(fileName)) {
-            engine.logger.trace("callSingle cache hit: {}", fileName);
-            return callSingleResult(engine, CACHE.get(fileName));
-        }
         long startTime = System.currentTimeMillis();
         engine.logger.trace("callSingle waiting for lock: {}", fileName);
         synchronized (CACHE) { // lock
-            if (CACHE.containsKey(fileName)) { // retry
+            // this thread is the 'winner'
+            engine.logger.info(">> lock acquired, begin callSingle: {}", fileName);
+            int minutes = engine.getConfig().getCallSingleCacheMinutes();
+            if ((minutes == 0) && CACHE.containsKey(fileName)) {
                 long endTime = System.currentTimeMillis() - startTime;
                 engine.logger.warn("this thread waited {} milliseconds for callSingle lock: {}", endTime, fileName);
                 return callSingleResult(engine, CACHE.get(fileName));
             }
-            // this thread is the 'winner'
-            engine.logger.info(">> lock acquired, begin callSingle: {}", fileName);
-            int minutes = engine.getConfig().getCallSingleCacheMinutes();
             Object result = null;
             File cacheFile = null;
             if (minutes > 0) {
@@ -230,7 +226,7 @@ public class ScenarioBridge implements PerfContext, EventContext {
                 try {
                     resultVar = engine.call(called, argVar, false);
                 } catch (Exception e) {
-                    // don't retain any vestiges of graal-js 
+                    // don't retain any vestiges of graal-js
                     RuntimeException re = new RuntimeException(e.getMessage());
                     // we do this so that an exception is also "cached"
                     resultVar = new Variable(re); // will be thrown at end


### PR DESCRIPTION
### Description

When performing "karate.configure('callSingleCache', { minutes: 15 })", some users would expect the feature to be executed again every 15min when doing "karate.callSingle(feature, args)"

- Relevant Issues : The feature executed once by "callSingle" is not executed again when using  "callSingleCache"
- Relevant PRs
  - Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
