### PR TITLE
Upgrade Gatling to 3.7.4

### DIFF
--- a/examples/gatling/pom.xml
+++ b/examples/gatling/pom.xml
@@ -12,7 +12,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.version>3.6.0</maven.compiler.version>
         <karate.version>1.1.0</karate.version>
-        <gatling.plugin.version>3.1.2</gatling.plugin.version>
+        <gatling.plugin.version>4.1.1</gatling.plugin.version>
     </properties>    
 
     <dependencies>
@@ -21,7 +21,7 @@
             <artifactId>karate-gatling</artifactId>
             <version>${karate.version}</version>
             <scope>test</scope>
-        </dependency>		
+        </dependency>
     </dependencies>
 
     <build>
@@ -44,6 +44,30 @@
                     <target>${java.version}</target>
                     <compilerArgument>-Werror</compilerArgument>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>4.5.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <args>
+                                <arg>-Jbackend:GenBCode</arg>
+                                <arg>-Jdelambdafy:method</arg>
+                                <arg>-target:jvm-1.8</arg>
+                                <arg>-deprecation</arg>
+                                <arg>-feature</arg>
+                                <arg>-unchecked</arg>
+                                <arg>-language:implicitConversions</arg>
+                                <arg>-language:postfixOps</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>io.gatling</groupId>

--- a/examples/profiling-test/pom.xml
+++ b/examples/profiling-test/pom.xml
@@ -12,7 +12,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.version>3.6.0</maven.compiler.version>
         <karate.version>1.1.0</karate.version>
-        <gatling.plugin.version>3.1.2</gatling.plugin.version>
+        <gatling.plugin.version>4.1.1</gatling.plugin.version>
     </properties>    
 
     <dependencies>
@@ -44,6 +44,30 @@
                     <target>${java.version}</target>
                     <compilerArgument>-Werror</compilerArgument>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>4.5.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <args>
+                                <arg>-Jbackend:GenBCode</arg>
+                                <arg>-Jdelambdafy:method</arg>
+                                <arg>-target:jvm-1.8</arg>
+                                <arg>-deprecation</arg>
+                                <arg>-feature</arg>
+                                <arg>-unchecked</arg>
+                                <arg>-language:implicitConversions</arg>
+                                <arg>-language:postfixOps</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>io.gatling</groupId>

--- a/karate-gatling/README.md
+++ b/karate-gatling/README.md
@@ -68,9 +68,7 @@ Refer: https://twitter.com/ptrthomas/status/986463717465391104
 </dependency>  
 ```
 
-Since the above does *not* include the [`karate-apache` (or `karate-jersey`)]((https://github.com/intuit/karate#maven)) dependency you will need to include that as well.
-
-You will also need the [Gatling Maven Plugin](https://github.com/gatling/gatling-maven-plugin), refer to the [sample project](../examples/gatling) for how to use this for a typical Karate project where feature files are in `src/test/java`. For convenience we recommend you keep even the Gatling simulation files in the same folder hierarchy, even though they are technically files with a `*.scala` extension.
+You will also need the [Gatling Maven Plugin](https://github.com/gatling/gatling-maven-plugin) and the [Scala Maven Pugin](https://github.com/davidB/scala-maven-plugin). Refer to the [sample project](../examples/gatling) for how to use this for a typical Karate project where feature files are in `src/test/java`. For convenience we recommend you keep even the Gatling simulation files in the same folder hierarchy, even though they are technically files with a `*.scala` extension.
 
 ```xml
   <plugin>

--- a/karate-gatling/pom.xml
+++ b/karate-gatling/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>io.gatling.highcharts</groupId>
             <artifactId>gatling-charts-highcharts</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.netty</groupId>
@@ -30,9 +30,8 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.13.6</version>
-            <scope>provided</scope>            
-        </dependency>               
+            <version>2.13.8</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -54,7 +53,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.5.3</version>
+                <version>4.5.6</version>
                 <executions>
                     <execution>
                         <goals>
@@ -79,7 +78,7 @@
             <plugin>
                 <groupId>io.gatling</groupId>
                 <artifactId>gatling-maven-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>4.1.1</version>
                 <configuration>
                     <disableCompiler>true</disableCompiler>
                     <skip>${skipTests}</skip>


### PR DESCRIPTION
### Description

- Relevant Issues : #1794 
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

This PR will upgrade the core Gatling libraries from 3.6.0 to 3.7.4.  Additionally, it will upgrade the Gatling Maven Plugin from 3.1.2 to 4.1.1. No code changes were required to support upgrading the core libraries. However, the plugin upgrade requires the changes outlined below:

Starting with version 4.0.0, the [Gatling Maven Plugin will no longer compile Scala code](https://gatling.io/docs/gatling/reference/current/extensions/maven_plugin/#scala).  As a result, projects that use Karate Gatling will need to explicitly include the [Scala Maven Plugin](https://github.com/davidB/scala-maven-plugin) and Scala Library to compile their Scala simulation files. I have changed the scope of the Scala Library to ensure that it will be available to our end users, and I have updated the examples to show how to include the required plugin.