### PR TITLE
Fix content type handling to account for other params

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
@@ -50,13 +50,13 @@ public enum ResourceType {
     MULTIPART("multipart/form-data", vals("multipart"), vals()),
     URLENCODED("application/x-www-form-urlencoded", vals("urlencoded"), vals()),
     BINARY("application/octet-stream", vals("octet"), vals()),
-    RDFXML("application/rdf+xml", vals("xml", "rdf"), vals(".rdf")),
-    NTRIPLES("application/n-triples", vals("rdf"), vals(".nt")),
-    TURTLE("text/turtle", vals("rdf"), vals(".ttl")),
-    NQUADS("application/n-quads", vals("rdf"), vals(".nq")),
-    TRIG("application/trig", vals("rdf"), vals(".trig")),
-    N3("text/n3", vals("rdf"), vals(".n3")),
-    JSONLD("application/ld+json", vals("json", "rdf"), vals(".jsonld"));
+    RDFXML("application/rdf+xml", vals("rdf", "rdf+xml"), vals("rdf")),
+    NTRIPLES("application/n-triples", vals("triples"), vals("nt")),
+    TURTLE("text/turtle", vals("turtle"), vals("ttl")),
+    NQUADS("application/n-quads", vals("quads"), vals("nq")),
+    TRIG("application/trig", vals("trig"), vals("trig")),
+    N3("text/n3", vals("n3"), vals("n3")),
+    JSONLD("application/ld+json", vals("ld+json"), vals("jsonld"));
 
     private static String[] vals(String... values) {
         return values;
@@ -91,8 +91,7 @@ public enum ResourceType {
             return null;
         }
         String extension = path.substring(pos + 1).trim().toLowerCase();
-        ResourceType rt = EXTENSION_MAP.get(extension);
-        return rt == null ? null : rt;
+        return EXTENSION_MAP.get(extension);
     }
 
     public String getExtension() {
@@ -120,7 +119,7 @@ public enum ResourceType {
                 return false;
         }
     }
-    
+
     public boolean isUrlEncodedOrMultipart() {
         switch (this) {
             case URLENCODED:
@@ -128,7 +127,7 @@ public enum ResourceType {
                 return true;
             default:
                 return false;
-        }        
+        }
     }
 
     public boolean isHtml() {

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
@@ -304,7 +304,7 @@ class KarateMockHandlerTest {
         );
         matchVar("response", "foo=bar");
     }
-    
+
     @Test
     void testFormFieldAsArray() {
         background().scenario(
@@ -317,7 +317,7 @@ class KarateMockHandlerTest {
                 "method post"
         );
         matchVar("response", "foo=bar1&foo=bar2");
-    }    
+    }
 
     @Test
     void testMultiPartField() {
@@ -346,7 +346,7 @@ class KarateMockHandlerTest {
         );
         matchVar("response", "{ foo: [{ name: 'foo', value: '#notnull', contentType: 'text/plain', charset: 'UTF-8', filename: 'foo.txt', transferEncoding: '7bit' }] }");
     }
-    
+
     @Test
     void testMultiPartFileNullCharset() {
         background().scenario(
@@ -360,7 +360,7 @@ class KarateMockHandlerTest {
                 "method post"
         );
         matchVar("response", "{ foo: [{ name: 'foo', value: '#notnull', contentType: 'text/plain', charset: 'UTF-8', filename: 'foo.txt', transferEncoding: '7bit' }] }");
-    }    
+    }
 
     @Test
     void testConfigureResponseHeaders() {
@@ -468,6 +468,23 @@ class KarateMockHandlerTest {
     }
 
     @Test
+    void testResponseContentTypeForNonXmlWithTagsAndCharset() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def responseHeaders = { 'Content-Type': 'text/turtle; charset=UTF-8' }",
+                "def response = '<http://example.org/#hello> a <http://example.org/#greeting> .'");
+        run(
+                URL_STEP,
+                "path 'hello'",
+                "method get",
+                "match header content-type contains 'text/turtle'",
+                "match header content-type != 'text/turtle'",
+                "match responseType == 'string'",
+                "match response == '<http://example.org/#hello> a <http://example.org/#greeting> .'"
+        );
+    }
+
+    @Test
     void testWildcardLikePathMatch() {
         background().scenario(
                 "requestUri.startsWith('hello/')",
@@ -532,8 +549,8 @@ class KarateMockHandlerTest {
                 "method get",
                 "match response == 'hello/world'"
         );
-    }  
-    
+    }
+
     @Test
     void testPathWithTrailingSlash() {
         background().scenario(
@@ -545,6 +562,6 @@ class KarateMockHandlerTest {
                 "method get",
                 "match response == 'hello/world/'"
         );
-    }     
+    }
 
 }

--- a/karate-core/src/test/java/com/intuit/karate/http/HttpLoggerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/http/HttpLoggerTest.java
@@ -1,0 +1,174 @@
+package com.intuit.karate.http;
+
+import com.intuit.karate.LogAppender;
+import com.intuit.karate.Logger;
+import com.intuit.karate.core.Config;
+import com.intuit.karate.core.DummyClient;
+import com.intuit.karate.core.MockHandler;
+import com.intuit.karate.shell.StringLogAppender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.intuit.karate.TestUtils.FeatureBuilder;
+import static com.intuit.karate.TestUtils.match;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test body and content type handling for request and response logging.
+ * @author edwardsph
+ */
+class HttpLoggerTest {
+
+    HttpClient client = new DummyClient();
+    MockHandler handler;
+    FeatureBuilder feature;
+    HttpRequestBuilder httpRequestBuilder;
+    HttpRequest request;
+    Logger testLogger = new Logger();
+    Config config = new Config();
+    LogAppender logAppender = new StringLogAppender(false);
+    HttpLogger httpLogger;
+
+    private static final String TURTLE_SAMPLE = "<http://example.org/hello> <http://example.org/#linked> <http://example.org/world> .";
+
+    @BeforeEach
+    void beforeEach() {
+        httpRequestBuilder = new HttpRequestBuilder(client).method("GET");
+        testLogger.setAppender(logAppender);
+        httpLogger = new HttpLogger(testLogger);
+    }
+
+    void setup(String path, String body, String contentType) {
+        feature = FeatureBuilder.background().scenario(
+                "pathMatches('/"+ path + "')",
+                "def response = '" + body + "'",
+                "def responseHeaders = {'Content-Type': '" + contentType + "'}"
+        );
+    }
+
+    private Response handle() {
+        handler = new MockHandler(feature.build());
+        request = httpRequestBuilder.build();
+        Response response = handler.handle(request.toRequest());
+        httpRequestBuilder = new HttpRequestBuilder(client).method("GET");
+        return response;
+    }
+
+    @Test
+    void testRequestLoggingPlain() {
+        HttpRequest httpRequest = httpRequestBuilder.body("hello").contentType("text/plain").path("/plain").build();
+        httpLogger.logRequest(config, httpRequest);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains("hello"));
+        assertTrue(logs.contains("Content-Type: text/plain"));
+    }
+
+    @Test
+    void testRequestLoggingJson() {
+        HttpRequest httpRequest = httpRequestBuilder.body("{a: 1}").contentType("application/json").path("/ttl").build();
+        httpLogger.logRequest(config, httpRequest);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains("{a: 1}"));
+        assertTrue(logs.contains("Content-Type: application/json"));
+    }
+
+    @Test
+    void testRequestLoggingXml() {
+        HttpRequest httpRequest = httpRequestBuilder.body("<hello>world</hello>").contentType("application/xml").path("/ttl").build();
+        httpLogger.logRequest(config, httpRequest);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains("<hello>world</hello>"));
+        assertTrue(logs.contains("Content-Type: application/xml"));
+    }
+
+
+    @Test
+    void testRequestLoggingTurtle() {
+        HttpRequest httpRequest = httpRequestBuilder.body(TURTLE_SAMPLE).contentType("text/turtle").path("/ttl").build();
+        httpLogger.logRequest(config, httpRequest);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains(TURTLE_SAMPLE));
+        assertTrue(logs.contains("Content-Type: text/turtle"));
+    }
+
+    @Test
+    void testRequestLoggingTurtleWithCharset() {
+        HttpRequest httpRequest = httpRequestBuilder.body(TURTLE_SAMPLE).contentType("text/turtle; charset=UTF-8").path("/ttl").build();
+        httpLogger.logRequest(config, httpRequest);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains(TURTLE_SAMPLE));
+        assertTrue(logs.contains("Content-Type: text/turtle; charset=UTF-8"));
+    }
+
+    @Test
+    void testResponseLoggingPlain() {
+        setup("plain", "hello", "text/plain");
+        httpRequestBuilder.path("/plain");
+        Response response = handle();
+        match(response.getBodyAsString(), "hello");
+        match(response.getContentType(), "text/plain");
+
+        httpLogger.logResponse(config, request, response);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains("hello"));
+        assertTrue(logs.contains("Content-Type: text/plain"));
+    }
+
+    @Test
+    void testResponseLoggingJson() {
+        setup("json", "{a: 1}", "application/json");
+        httpRequestBuilder.path("/json");
+        Response response = handle();
+        match(response.getBodyAsString(), "{a: 1}");
+        match(response.getContentType(), "application/json");
+
+        httpLogger.logResponse(config, request, response);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains("{a: 1}"));
+        assertTrue(logs.contains("Content-Type: application/json"));
+    }
+
+    @Test
+    void testResponseLoggingXml() {
+        setup("xml", "<hello>world</hello>", "application/xml");
+        httpRequestBuilder.path("/xml");
+        Response response = handle();
+        match(response.getBodyAsString(), "<hello>world</hello>");
+        match(response.getContentType(), "application/xml");
+
+        httpLogger.logResponse(config, request, response);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains("<hello>world</hello>"));
+        assertTrue(logs.contains("Content-Type: application/xml"));
+    }
+
+    @Test
+    void testResponseLoggingTurtle() {
+        setup("ttl", TURTLE_SAMPLE, "text/turtle");
+        httpRequestBuilder.path("/ttl");
+        Response response = handle();
+        assertEquals(response.getBodyAsString(), TURTLE_SAMPLE);
+        assertTrue(response.getContentType().contains("text/turtle"));
+
+        httpLogger.logResponse(config, request, response);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains(TURTLE_SAMPLE));
+        assertTrue(logs.contains("Content-Type: text/turtle"));
+    }
+
+    @Test
+    void testResponseLoggingTurtleWithCharset() {
+        setup("ttl", TURTLE_SAMPLE, "text/turtle; charset=UTF-8");
+        httpRequestBuilder.path("/ttl");
+        Response response = handle();
+        assertEquals(response.getBodyAsString(), TURTLE_SAMPLE);
+        assertEquals(response.getContentType(), "text/turtle; charset=UTF-8");
+
+        httpLogger.logResponse(config, request, response);
+        String logs = logAppender.collect();
+        assertTrue(logs.contains(TURTLE_SAMPLE));
+        assertTrue(logs.contains("Content-Type: text/turtle; charset=UTF-8"));
+    }
+
+}


### PR DESCRIPTION
### Description

Whilst the PR below resolved some issues, it left an ongoing problem where request and response bodies were not being logged for some content types. I realised that I had misunderstood the use of `contentLike` in `ResourceType`. I thought it was grouping similarly handled content types but realise it was actually a list of keywords that could be used to match content types when an exact match failed. The exact match will always fail if there is a charset included in the content type in an http request. I wondered about splitting off the charset before matching but you had previously pointed out the `contentLike` lookup made this unnecessary - well it would have if I had registered the ResourceTypes correctly.

This PR resolves that issue and adds some tests:
* an additional test in KarateMockHandlerTest for the charset case
* a set of tests for HttpLogger that check the body and content-type are both logged correctly
These tests could be a lot more extensive but they demonstrate that the resource type lookup is fixed for the benefit of logging and reporting.

- Relevant Issues : #1462 
- Relevant PRs : #1479
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
