### PR TITLE
Issue #1834 - Publish Non-Shaded JAR For karate-core

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -192,6 +192,8 @@
                                     <goal>shade</goal>
                                 </goals>
                                 <configuration>
+                                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                                    <shadedClassifierName>all</shadedClassifierName>
                                     <artifactSet>
                                         <includes>
                                             <include>com.linecorp.armeria:*</include>


### PR DESCRIPTION
### Description

- Relevant Issues : #1869 
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [X] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Publishing a non-shaded JAR will enable clients to upgrade and/or exclude dependencies based on their specific use cases.  For example, if the version of Netty used by Karate is discovered to have a severe security flaw, our users can specify a newer version of Netty in their pom to override the dependency inherited from Karate.  This is currently not possible with the shaded JAR.

Both JARs will be published to Maven Central under `com/intuit/karate/karate-core/1.2.0`, and the filenames will be `karate-core-1.2.0.jar` and `karate-core-1.2.0-all.jar`.

Clients will reference the non-shaded JAR using
```xml
<dependency>
    <groupId>com.intuit.karate</groupId>
    <artifactId>karate-core</artifactId>
    <version>1.2.0</version>
</dependency>
```

And they can reference the shaded JAR with
```xml
<dependency>
    <groupId>com.intuit.karate</groupId>
    <artifactId>karate-core</artifactId>
    <version>1.2.0</version>
    <classifier>all</classifier>
</dependency>
```