### PR TITLE
fix buggy UI iframe behavior

### DIFF
--- a/karate-e2e-tests/src/test/java/driver/00.feature
+++ b/karate-e2e-tests/src/test/java/driver/00.feature
@@ -45,7 +45,7 @@ Scenario:
 * call read('11.feature')
 
 # switchPage() with external URLs
-# * call read('13.feature')
+* call read('13.feature')
 
 # survive Target.detachedFromTarget with nested iframes
-# * call read('14.feature')
+* call read('14.feature')

--- a/karate-e2e-tests/src/test/java/driver/DockerRunner.java
+++ b/karate-e2e-tests/src/test/java/driver/DockerRunner.java
@@ -40,12 +40,12 @@ class DockerRunner {
     }
 
     // use these only for local testing
-    //@Test
+    @Test
     void testSingle13() {
         run("13");
     }
 
-    //@Test
+    @Test
     void testSingle14() {
         run("14");
     }


### PR DESCRIPTION
### Description

Fix buggy iframe behavior introduced in https://github.com/karatelabs/karate/pull/1944.

Specifically, we should be returning to the main frame (i.e. last page/tab) and not the root frame (i.e. first page/tab) when clearing the frame selection via `switchFrame(null)`.

Also included in this PR is an update to subscribe to `Target.targetInfoChanged` events via `Target.setDiscoverTargets`. This is needed to detect when a frame has been reloaded / swapped which would cause any existing execution context invalid.

- Relevant Issues : https://github.com/karatelabs/karate/issues/1942
- Relevant PRs : https://github.com/karatelabs/karate/pull/1944
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
