### PR TITLE
F masking enhancement

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <antlr.version>4.9.2</antlr.version>
         <graal.version>21.2.0</graal.version>
+        <cucumber.reporting.version>5.3.1</cucumber.reporting.version>
     </properties>
 
     <dependencies>
@@ -117,6 +118,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.masterthought</groupId>
+            <artifactId>cucumber-reporting</artifactId>
+            <version>${cucumber.reporting.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioResult.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioResult.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  *
@@ -106,6 +107,16 @@ public class ScenarioResult implements Comparable<ScenarioResult> {
                 call.setLine(stepResult.getStep().getLine());
                 call.setPrefix(StringUtils.repeat('>', depth));
                 call.setText(fr.getCallNameForReport());
+                for(ScenarioResult scenarioResult: fr.getScenarioResults()){
+                    for (StepResult sr: scenarioResult.getStepResults()){
+                        if(sr.isHidden()){
+                            //fr.setCallArg(null);
+                            Map<String, Object> callArgMap = fr.getCallArg();
+                            callArgMap.keySet().stream().forEach(x-> fr.getCallArg().put(x, "***"));
+                            break;
+                        }
+                    }
+                }
                 call.setDocString(fr.getCallArgPretty());
                 StepResult callResult = new StepResult(call, Result.passed(0));
                 callResult.setHidden(stepResult.isHidden());

--- a/karate-core/src/test/java/com/intuit/karate/report/CucumberMaskReportTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/report/CucumberMaskReportTest.java
@@ -1,0 +1,37 @@
+package com.intuit.karate.report;
+
+import com.intuit.karate.Results;
+import com.intuit.karate.Runner;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.apache.commons.io.FileUtils;
+import net.masterthought.cucumber.Configuration;
+import net.masterthought.cucumber.ReportBuilder;
+public class CucumberMaskReportTest {
+
+    @Test
+    void testParallel() {
+        Results results = Runner.path("classpath:com/intuit/karate/report/maskCucumberReport.feature")
+                .tags("~@ignore")
+                .outputCucumberJson(true)
+                .parallel(5);
+        generateReport(results.getReportDir());
+        assertEquals(0, results.getFailCount(), results.getErrorMessages());
+    }
+
+    // To generate cucumber HTML report
+    public static void generateReport(String karateOutputPath) {
+        Collection<File> jsonFiles = FileUtils.listFiles(new File(karateOutputPath), new String[] {"json"}, true);
+        List<String> jsonPaths = new ArrayList<>(jsonFiles.size());
+        jsonFiles.forEach(file -> jsonPaths.add(file.getAbsolutePath()));
+        Configuration config = new Configuration(new File("target"), "sample");
+        ReportBuilder reportBuilder = new ReportBuilder(jsonPaths, config);
+        reportBuilder.generateReports();
+    }
+}

--- a/karate-core/src/test/java/com/intuit/karate/report/maskCucumberReport.feature
+++ b/karate-core/src/test/java/com/intuit/karate/report/maskCucumberReport.feature
@@ -1,0 +1,40 @@
+Feature: sample karate test script
+  for help, see: https://github.com/intuit/karate/wiki/IDE-Support
+
+  Background:
+    * url 'https://jsonplaceholder.typicode.com'
+
+  Scenario: get all users and then get the first user by id
+    Given path 'users'
+    When method get
+    Then status 200
+
+    * def first = response[0]
+
+    Given path 'users', first.id
+    When method get
+    Then status 200
+
+  Scenario: create a user and then get it by id
+    * def user =
+      """
+      {
+        "name": "Test User",
+        "username": "testuser",
+        "email": "test@user.com",
+        "address": {
+          "street": "Has No Name",
+          "suite": "Apt. 123",
+          "city": "Electri",
+          "zipcode": "54321-6789"
+        }
+      }
+      """
+
+    Given url 'https://jsonplaceholder.typicode.com/users'
+    And request user
+    When method post
+    Then status 201
+
+    * def id = response.id
+    * print 'created id is: ', id

--- a/karate-core/src/test/java/com/intuit/karate/report/suite.feature
+++ b/karate-core/src/test/java/com/intuit/karate/report/suite.feature
@@ -1,0 +1,11 @@
+Feature: sample karate test script
+  for help, see: https://github.com/intuit/karate/wiki/IDE-Support
+
+  Background:
+    Given url baseURL
+    * configure report = false
+  @test1
+  Scenario: Test and variables should not come in cucumber report
+    Given path 'users'
+    When method get
+    Then status 200

--- a/karate-core/src/test/java/com/intuit/karate/report/suite.feature
+++ b/karate-core/src/test/java/com/intuit/karate/report/suite.feature
@@ -4,6 +4,7 @@ Feature: sample karate test script
   Background:
     Given url baseURL
     * configure report = false
+
   @test1
   Scenario: Test and variables should not come in cucumber report
     Given path 'users'

--- a/karate-core/src/test/java/com/intuit/karate/report/suite2.feature
+++ b/karate-core/src/test/java/com/intuit/karate/report/suite2.feature
@@ -1,0 +1,11 @@
+Feature: sample karate test script
+  for help, see: https://github.com/intuit/karate/wiki/IDE-Support
+
+  Background:
+    Given url baseURL
+
+  @test2
+  Scenario: Test and variables should not come in cucumber report
+    Given path 'users'
+    When method get
+    Then status 200

--- a/karate-core/src/test/java/karate-config.js
+++ b/karate-core/src/test/java/karate-config.js
@@ -7,8 +7,8 @@ function fn() {
     baseURL: 'https://jsonplaceholder.typicode.com',
     number: '2'
   }
-  var results = karate.callSingle('classpath:com/intuit/karate/report/suite.feature@test1',config);
-  results = karate.callSingle('classpath:com/intuit/karate/report/suite2.feature@test2',config);
+  //var results = karate.callSingle('classpath:com/intuit/karate/report/suite.feature@test1',config);
+  //results = karate.callSingle('classpath:com/intuit/karate/report/suite2.feature@test2',config);
   return {
 
     configSource: 'normal' }

--- a/karate-core/src/test/java/karate-config.js
+++ b/karate-core/src/test/java/karate-config.js
@@ -1,3 +1,15 @@
-function fn() {   
-  return { configSource: 'normal' }
+function fn() {
+  console.log("HEllo");
+  var env = karate.env; // get system property 'karate.env'
+  var config = {
+    env: env,
+    secret: 'secretvalueshouldnotcomeincucumberreport',
+    baseURL: 'https://jsonplaceholder.typicode.com',
+    number: '2'
+  }
+  var results = karate.callSingle('classpath:com/intuit/karate/report/suite.feature@test1',config);
+  results = karate.callSingle('classpath:com/intuit/karate/report/suite2.feature@test2',config);
+  return {
+
+    configSource: 'normal' }
 }


### PR DESCRIPTION
Issue #1837 - Fix Details: There is no way to access ScenarioRuntime.engine.getConfig() in the Result phase. So in order to find out if call args(any args defined in config of karate-config.js) needs to be hidden, I am checking the if a step result has field hidden == true then I am making callArgs values set to ***

**HOW TO TEST AND VALIDATE**
STEP 1: 
**NOTE:  To test the fix, uncomment these line in karate-core/src/test/java/karate-config.js**

```
 //var results = karate.callSingle('classpath:com/intuit/karate/report/suite.feature@test1',config);
  //results = karate.callSingle('classpath:com/intuit/karate/report/suite2.feature@test2',config);
```
STEP 2: 
Run test karate-core/src/test/java/com/intuit/karate/report/CucumberMaskReportTest.java

STEP 3:
Check the cucumber-html-reports under target folder.
You should see that for step definition - 
 - com/intuit/karate/report/suite.feature@test1 the values are masked with *** as file has 
 ```
 * config report = false
```
- com/intuit/karate/report/suite.feature@test1 the values are NOT masked with *** as file is not using report = false 

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [X ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
