### PR TITLE
Issue #1837 : Added a new property in Config.java - showCallArgs. If …

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Config.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Config.java
@@ -101,6 +101,7 @@ public class Config {
     // report config
     private boolean showLog = true;
     private boolean showAllSteps = true;
+    private boolean showCallArgs = true;
 
     // call single cache config
     private int callSingleCacheMinutes = 0;
@@ -194,12 +195,15 @@ public class Config {
                     Map<String, Object> map = value.getValue();
                     showLog = get(map, "showLog", showLog);
                     showAllSteps = get(map, "showAllSteps", showAllSteps);
+                    showCallArgs = get(map, "showCallArgs", showCallArgs);
                 } else if (value.isTrue()) {
                     showLog = true;
                     showAllSteps = true;
+                    showCallArgs = true;
                 } else {
                     showLog = false;
                     showAllSteps = false;
+                    showCallArgs = false;
                 }
                 return false;
             case "driver":
@@ -591,4 +595,7 @@ public class Config {
         this.continueAfterContinueOnStepFailure = continueAfterContinueOnStepFailure;
     }
 
+    public boolean isShowCallArgs() {
+        return showCallArgs;
+    }
 }

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioResult.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioResult.java
@@ -106,7 +106,9 @@ public class ScenarioResult implements Comparable<ScenarioResult> {
                 call.setLine(stepResult.getStep().getLine());
                 call.setPrefix(StringUtils.repeat('>', depth));
                 call.setText(fr.getCallNameForReport());
-                call.setDocString(fr.getCallArgPretty());
+                if(fr.getConfig().isShowCallArgs()) {
+                    call.setDocString(fr.getCallArgPretty());
+                }
                 StepResult callResult = new StepResult(call, Result.passed(0));
                 callResult.setHidden(stepResult.isHidden());
                 list.add(callResult.toCucumberJson());


### PR DESCRIPTION
…the property is set to false then steps will not show. Here are the three ways

1. #* configure report = { showLog: true, showAllSteps: false, showCallArgs: false } ---> callArgs will not show
2. #* configure report = { showLog: true, showAllSteps: false, showCallArgs: true } ---> CallArgs will show
3. #* configure report = false ---> CallArgs will not show

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [X ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
