### PR TITLE
Fix jdk-compat workflow

### DIFF
--- a/.github/workflows/jdk-compat.yml
+++ b/.github/workflows/jdk-compat.yml
@@ -15,7 +15,7 @@ jobs:
       uses: oracle-actions/setup-java@v1
       with:
         website: jdk.java.net
-        release: ${{ matrix.feature }}    
+        release: 18
     - name: cache maven packages
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Fix workflow configuration by specifying `18` as value for `release`.