### PR TITLE
Issue 1963: Fix for some cookies not passed to the next call

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/Response.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Response.java
@@ -121,10 +121,8 @@ public class Response implements ProxyObject {
         }
         Map<String, Map> map = new HashMap();
         for (String value : values) {
-            Cookie cookie = ClientCookieDecoder.STRICT.decode(value);
-            if (cookie != null) { // can be null if cookie contains invalid characters
-                map.put(cookie.name(), Cookies.toMap(cookie));
-            }
+            Cookie cookie = ClientCookieDecoder.LAX.decode(value);
+            map.put(cookie.name(), Cookies.toMap(cookie));
         }
         return map;
     }

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/invalid-cookie.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/invalid-cookie.feature
@@ -7,3 +7,10 @@ Background:
     * path 'invalid-cookie';
     * method get
     * status 200
+
+    # check that 'invalid' cookie is passed to the next call
+    * method get
+    * status 404
+    * def temp = karate.prevRequest
+    * def invalidCookie = temp.headers['Cookie']
+    * match invalidCookie contains ["detectedTimeZoneId=FLE Standard Time"]


### PR DESCRIPTION
### Description

Use `ClientCookieDecoder.LAX.decode(value)` to parse the cookies, so whenever an "Invalid" cookie is set it will not return null and the code won't skip mentioned cookie. I think checking whether cookies are valid or not is not the responsibility of the test framework. Also, sometimes it treats some cookies as invalid that do work pretty fine on Enterprise production applications.

- Relevant Issues : https://github.com/karatelabs/karate/issues/1963
- Relevant PRs : https://github.com/karatelabs/karate/pull/1782
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
