### PR TITLE
Add config for cucumber style feature name & description #1980

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -185,6 +185,7 @@ public class Runner {
         boolean outputHtmlReport = true;
         boolean outputJunitXml;
         boolean outputCucumberJson;
+        boolean cucumberStyleJson = false;
         boolean dryRun;
         boolean debugMode;
         Map<String, String> systemProperties;
@@ -219,6 +220,7 @@ public class Runner {
             b.outputHtmlReport = outputHtmlReport;
             b.outputJunitXml = outputJunitXml;
             b.outputCucumberJson = outputCucumberJson;
+            b.cucumberStyleJson = cucumberStyleJson;
             b.dryRun = dryRun;
             b.debugMode = debugMode;
             b.systemProperties = systemProperties;
@@ -524,6 +526,11 @@ public class Runner {
 
         public T outputCucumberJson(boolean value) {
             outputCucumberJson = value;
+            return (T) this;
+        }
+        
+        public T cucumberStyleJson(boolean value) {
+            cucumberStyleJson = value;
             return (T) this;
         }
 

--- a/karate-core/src/main/java/com/intuit/karate/Suite.java
+++ b/karate-core/src/main/java/com/intuit/karate/Suite.java
@@ -91,6 +91,7 @@ public class Suite implements Runnable {
     public final boolean outputHtmlReport;
     public final boolean outputCucumberJson;
     public final boolean outputJunitXml;
+    public final boolean cucumberStyleJson;
 
     public final boolean parallel;
     public final ExecutorService scenarioExecutor;
@@ -134,6 +135,7 @@ public class Suite implements Runnable {
             backupReportDir = false;
             outputHtmlReport = false;
             outputCucumberJson = false;
+            cucumberStyleJson = false;
             outputJunitXml = false;
             classLoader = Thread.currentThread().getContextClassLoader();
             clientFactory = rb.clientFactory == null ? HttpClientFactory.DEFAULT : rb.clientFactory;
@@ -169,6 +171,7 @@ public class Suite implements Runnable {
             backupReportDir = rb.backupReportDir;
             outputHtmlReport = rb.outputHtmlReport;
             outputCucumberJson = rb.outputCucumberJson;
+            cucumberStyleJson = rb.cucumberStyleJson;
             outputJunitXml = rb.outputJunitXml;
             dryRun = rb.dryRun;
             debugMode = rb.debugMode;
@@ -268,6 +271,7 @@ public class Suite implements Runnable {
             suiteReports.featureReport(this, fr).render();
         }
         if (outputCucumberJson) {
+        	fr.setCucumberStyleJson(cucumberStyleJson);
             ReportUtils.saveCucumberJson(reportDir, fr, null);
         }
         if (outputJunitXml) {

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureResult.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureResult.java
@@ -47,6 +47,8 @@ public class FeatureResult {
 
     private String resultDate;
     private String displayName; // mutable for users who want to customize
+    
+    private boolean cucumberStyleJson;
 
     private Map<String, Object> resultVariables;
     private Map<String, Object> callArg;
@@ -170,13 +172,22 @@ public class FeatureResult {
         map.put("keyword", Feature.KEYWORD);
         map.put("line", feature.getLine());
         map.put("uri", displayName);
-        map.put("name", displayName);
+        
+        map.put("name", (cucumberStyleJson && feature.getName() != null && !feature.getName().isEmpty()) 
+				? feature.getName().trim() : displayName);
+        
         map.put("id", StringUtils.toIdString(feature.getName()));
-        String temp = feature.getName() == null ? "" : feature.getName();
-        if (feature.getDescription() != null) {
-            temp = temp + "\n" + feature.getDescription();
-        }
-        map.put("description", temp.trim());
+        
+        if(cucumberStyleJson) {
+			map.put("description",  feature.getDescription() != null ? feature.getDescription() : "");
+		} else {
+			String temp = feature.getName() == null ? "" : feature.getName();
+			if (feature.getDescription() != null) {
+				temp = temp + "\n" + feature.getDescription();
+			}
+			map.put("description", temp.trim());
+		}
+        
         if (feature.getTags() != null) {
             map.put("tags", ScenarioResult.tagsToCucumberJson(feature.getTags()));
         }
@@ -211,6 +222,14 @@ public class FeatureResult {
     public String getDisplayName() {
         return displayName;
     }
+    
+    public boolean isCucumberStyleJson() {
+		return cucumberStyleJson;
+	}
+
+	public void setCucumberStyleJson(boolean cucumberStyleJson) {
+		this.cucumberStyleJson = cucumberStyleJson;
+	}
 
     public KarateException getErrorMessagesCombined() {
         List<String> errors = getErrors();

--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureResultTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureResultTest.java
@@ -45,4 +45,22 @@ class FeatureResultTest {
         match(cucumberClone, expected);
     }
 
+	@Test
+	void testCucumberStyleJsonConversion() {
+		run("feature-result-cucumber-style.feature");
+		FeatureResult featureResult = fr.result;
+		featureResult.setCucumberStyleJson(true);
+		Map<String, Object> results = featureResult.toCucumberJson();
+		match(results.get("name"), "Hello World");
+		match(results.get("description"), "Describe Hello World");
+	}
+
+	@Test
+	void testDefaultStyleJsonConversion() {
+		run("feature-result-cucumber-style.feature");
+		FeatureResult featureResult = fr.result;
+		Map<String, Object> results = featureResult.toCucumberJson();
+		match(results.get("name"), "com/intuit/karate/core/feature-result-cucumber-style.feature");
+		match(results.get("description"), "Hello World\nDescribe Hello World");
+	}
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/feature-result-cucumber-style.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/feature-result-cucumber-style.feature
@@ -1,0 +1,5 @@
+Feature: Hello World
+      Describe Hello World
+
+  Scenario: Hey All
+    * print 'Hello'


### PR DESCRIPTION
### Description


Added `cucumberStyleJson` option in the Runner.Builder to allow Cucumber style feature name and description values in the Json report. This is set to **_false_** by default, so it needs to explicitly added.
Usage - `.outputCucumberJson(true).cucumberStyleJson(true)`



- Relevant Issues : (compulsory) - Configuration to enable https://github.com/karatelabs/karate/issues/1980
- Relevant PRs : (optional)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
