### PR TITLE
Reset the signal after listening for a specific message.  This allows…

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/WebSocketClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/WebSocketClient.java
@@ -210,7 +210,9 @@ public class WebSocketClient implements WebSocketListener {
     public synchronized Object listen(long timeout) {
         try {
             logger.trace("entered listen wait state");
-            return SIGNAL.get(timeout, TimeUnit.MILLISECONDS);
+            Object result = SIGNAL.get(timeout, TimeUnit.MILLISECONDS);
+            SIGNAL = new CompletableFuture();
+            return result;
         } catch (Exception e) {
             logger.error("listen timed out: {}", e + "");
             return null;

--- a/karate-demo/src/test/java/demo/websocket/websocket.feature
+++ b/karate-demo/src/test/java/demo/websocket/websocket.feature
@@ -24,3 +24,25 @@ Scenario: using the websocket instance to send as well as receive messages
     * socket.send('Billie')
     * def result = socket.listen(5000)
     * match result == 'hello Billie !'
+
+Scenario: listen for multiple websocket messages
+    * def handler = function(msg){ return msg.startsWith('hello') }
+    * def socket = karate.webSocket(demoBaseUrl + '/websocket', handler)
+    * socket.send('Billie')
+    * def result = socket.listen(5000)
+    * match result == 'hello Billie !'
+    * socket.send('Bob')
+    * def result = socket.listen(5000)
+    * match result == 'hello Bob !'
+
+Scenario: change the websocket handler for messages
+    * def handler = function(msg){ return msg.contains('Billie') }
+    * def socket = karate.webSocket(demoBaseUrl + '/websocket', handler)
+    * socket.send('Billie')
+    * def result = socket.listen(5000)
+    * match result == 'hello Billie !'
+    * def handler = function(msg){ return msg.contains('Bob') }
+    * socket.setTextHandler(karate.toJava(handler))
+    * socket.send('Bob')
+    * def result = socket.listen(5000)
+    * match result == 'hello Bob !'


### PR DESCRIPTION
Reset the signal after listening for a specific message.  This allows for multiple calls to listen.  This is particularly helpful for a web application where the authentication is sent in the first frame, and we want to block for an acknolegement of that authentication before continuing with the remainder of our test.

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : #2003
- Relevant PRs : (optional)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
