### PR TITLE
Upgrade armeria to 1.16.0 fixing jackson-databind (CVE-2020-36518)

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.linecorp.armeria</groupId>
             <artifactId>armeria</artifactId>
-            <version>1.13.4</version>
+            <version>1.16.0</version>
         </dependency>              
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Upgrade armeria from 1.13.4 to 1.16.0. This indirectly upgrades
jackson-databind from 2.13.0 to 2.13.2.1 fixing a
Denial of Service (DoS) vulnerability in jackson-databind:
https://nvd.nist.gov/vuln/detail/CVE-2020-36518