### PR TITLE
updated the tests for the failures for issue 2039 fixes

### DIFF
--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -726,17 +726,17 @@ For example, to [`retry()`](#retry) until an HTML element is present and then [`
 * retry().click('#someId')
 ```
 
-Or to [wait until a button is enabled](#waituntilenabled) using the default retry configuration:
+Or to [wait until a button is enabled](#waitForEnabled) using the default retry configuration:
 
 ```cucumber
-# waitUntilEnabled() returns an "Element" instance
-* waitUntilEnabled('#someBtn').click()
+# waitForEnabled() returns an "Element" instance
+* waitForEnabled('#someBtn').click()
 ```
 
 Or to temporarily [over-ride the retry configuration](#retry) *and* wait:
 
 ```cucumber
-* retry(5, 10000).waitUntilEnabled('#someBtn').click()
+* retry(5, 10000).waitForEnabled('#someBtn').click()
 ```
 
 Or to move the [mouse()](#mouse) to a given `[x, y]` co-ordinate *and* perform a click:
@@ -996,7 +996,7 @@ Since moving the mouse is a common task, these short-cuts can be used:
 ```cucumber
 * mouse('#menuItem32').click()
 * mouse(100, 200).go()
-* waitUntilEnabled('#someBtn').mouse().click()
+* waitForEnabled('#someBtn').mouse().click()
 ```
 
 These are useful in situations where the "normal" [`click()`](#click) does not work - especially when the element you are clicking is not a normal hyperlink (`<a href="">`) or `<button>`.


### PR DESCRIPTION
### Description

Updated the `karate-core/README.md` for the changes done from commit id, `0da4f4140a46cf3ae61ef63661a5e04d9000509a`, to the documentation where, `waitUntilEnabled()` is replaced with, `waitForEnabled()`.

- Relevant Issues : [[UI docs] karate-core/README.md contains code examples with non-existing waitUntilEnabled() function #2039 ](https://github.com/karatelabs/karate/issues/2039)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [x] Addition or Improvement of documentation
