### PR TITLE
Added fixes to check variable instance of JsFunction for issue 2013 fixes

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Variable.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Variable.java
@@ -71,11 +71,15 @@ public class Variable {
     public Variable(Object o) {
         if (o instanceof Value) {
             o = new JsValue((Value) o).getValue();
+        } else if (o instanceof JsFunction) {
+            o = ((JsFunction) o).value;
         } else if (o instanceof JsValue) {
             o = ((JsValue) o).getValue();
         }
         if (o == null) {
             type = Type.NULL;
+        } else if (o instanceof JsFunction) {
+            type = Type.JS_FUNCTION;
         } else if (o instanceof Value) {
             Value v = (Value) o;
             if (v.canExecute()) {

--- a/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
@@ -42,7 +42,6 @@ public class StepRuntimeTest {
         Assertions.assertTrue(methodMatchList.stream().anyMatch(m -> m.getMethod().equals(method)));
         Assertions.assertTrue(methodMatchList.stream().anyMatch(m -> m.getArgs().equals(args)));
         Assertions.assertTrue(methodMatchList.stream().anyMatch(m -> m.toString().equals(methodSignature)));
-        System.out.println();
     }
 
     @Test


### PR DESCRIPTION
### Description

Added fixes to check if the provided object is an instance of `JsFunction` and then assign `value` and `type` accordingly.

- Relevant Issues :  [Retry Until failure leads to afterscenario not running #2013 ](https://github.com/karatelabs/karate/issues/2013)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
