### PR TITLE
Changes for removing redundant java println and using loggers instead in Test Classes

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
@@ -87,7 +87,6 @@ class IdeMainTest {
     @Test
     void testParsingCommandLineReportFormats() {
         Main options = IdeMain.parseIdeCommandLine("cucumber.api.cli.Main --plugin org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter --monochrome -e local -f html,json,cucumber:json,junit:xml -g /dev/config/dir /dev/test/todos.feature:27");
-        System.out.println();
         assertIterableEquals(options.formats, new ArrayList<String>() {
             {
                 add("html");

--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
@@ -99,7 +99,6 @@ class FeatureRuntimeTest {
     @Test
     void testAlign() {
         run("align.feature");
-        System.out.println(fr.result.getVariables());
         match(fr.result.getVariables(), "{ configSource: 'normal', functionFromKarateBase: '#notnull', text: 'hello bar world' , cats: '#notnull', myJson: {}}}");
     }
 

--- a/karate-core/src/test/java/com/intuit/karate/core/parser/FeatureParserTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/parser/FeatureParserTest.java
@@ -279,8 +279,5 @@ class FeatureParserTest {
         fr = FeatureRuntime.of(new Suite(builder), feature);
         outline = feature.getSection(0).getScenarioOutline();
         assertEquals(7, outline.getScenarios(fr).size());
-
-
-        System.out.println();
     }
 }

--- a/karate-core/src/test/java/com/intuit/karate/driver/appium/MobileDriverOptionsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/driver/appium/MobileDriverOptionsTest.java
@@ -96,8 +96,5 @@ class MobileDriverOptionsTest {
         Map<String, Object> options5 = Json.of(driverSession5).get("$");
         String browserName5 = MobileDriverOptions.getBrowserName(options5);
         Assertions.assertEquals(null, browserName5);
-        System.out.println(browserName);
-
-
     }
 }

--- a/karate-core/src/test/java/com/intuit/karate/fatjar/ProxyServerRunner.java
+++ b/karate-core/src/test/java/com/intuit/karate/fatjar/ProxyServerRunner.java
@@ -2,6 +2,8 @@ package com.intuit.karate.fatjar;
 
 import com.intuit.karate.http.ProxyServer;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -9,10 +11,12 @@ import org.junit.jupiter.api.Test;
  */
 class ProxyServerRunner {
 
+    private static final Logger logger = LoggerFactory.getLogger(ProxyServerRunner.class);
+
     @Test
     void testProxy() {
         ProxyServer proxy = new ProxyServer(5000, req -> {
-            System.out.println("*** " + req.uri());
+            logger.info("*** {}", req.uri());
             return null;
         }, null);
         proxy.waitSync();

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/syntax/SyntaxPerfRunner.java
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/syntax/SyntaxPerfRunner.java
@@ -3,12 +3,16 @@ package com.intuit.karate.junit4.syntax;
 import com.intuit.karate.Runner;
 import java.util.Collections;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author pthomas3
  */
 public class SyntaxPerfRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(SyntaxPerfRunner.class);
     
     @Test
     public void testPerf() {
@@ -18,7 +22,7 @@ public class SyntaxPerfRunner {
             Runner.runFeature(getClass(), "syntax.feature", Collections.EMPTY_MAP, true);
         }
         long elapsedTime = System.currentTimeMillis() - startTime;
-        System.out.println("elapsed time: " + elapsedTime);
+        logger.info("elapsed time: {}", elapsedTime);
         // 25.5 seconds for git 76c92bd
         // 14.0 seconds after refactoring
         // 11.0 seconds after second wave git 20445d5


### PR DESCRIPTION
### Description

Following small PR have fixes around removing redundant java println and using loggers instead. As `System.out.println` is an IO-operation and therefor is time consuming. The Problem with using it in the code is, that program will wait until the println has finished. It comes with several disadvantages that affect its usability in many situations.

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
