### PR TITLE
Xray integration #1902

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/report/ReportUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/report/ReportUtils.java
@@ -157,37 +157,20 @@ public class ReportUtils {
     private static Element addCustomTags(Element testCase, Document doc, ScenarioResult sr){
         //Adding requirement and test tags
         Element properties = null;   
-        String custom_tags = System.getProperty("custom_tags");         
-        String custom_xml_tags = System.getProperty("custom_xml_tags");  
 
         if (sr.getScenario() != null){
             List<String> tags = sr.getScenario().getTagsEffective().getTags();
-            if (tags.size() > 0 && custom_tags != null && custom_xml_tags != null){
+            if (tags.size() > 0 ){
                 properties = doc.createElement("properties");
                 
-                custom_tags = custom_tags.toLowerCase();
-                custom_xml_tags = custom_xml_tags.toLowerCase();
-                String[] custom_tags_ar = custom_tags.split("\\s*,\\s*");
-                String[] custom_xml_tags_ar = custom_xml_tags.split("\\s*,\\s*");
-                int custom_tags_size = custom_tags_ar.length;
-
                 for (String tag : tags) {                        
                     String[] innerTags = tag.split("=");
                     int size = innerTags.length;
                     Element requirement = doc.createElement("property");
-                    boolean add_element = false;
                     
-                    for (int i=0;i<custom_tags_size;i++){
-                        if(custom_tags_ar[i].trim().equals(innerTags[0].toLowerCase())){                            
-                            requirement.setAttribute("name", custom_xml_tags_ar[i]);     
-                            add_element = true;                       
-                        }
-                    }
-                    if (size > 1){
+                    if(size > 1){
+                        requirement.setAttribute("name", innerTags[0]);     
                         requirement.setAttribute("value", innerTags[1]);
-                    }
-                    
-                    if (add_element){
                         properties.appendChild(requirement);
                     }
                 }

--- a/karate-core/src/main/java/com/intuit/karate/report/ReportUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/report/ReportUtils.java
@@ -154,6 +154,49 @@ public class ReportUtils {
         return error;
     }
 
+    private static Element addCustomTags(Element testCase, Document doc, ScenarioResult sr){
+        //Adding requirement and test tags
+        Element properties = null;   
+        String custom_tags = System.getProperty("custom_tags");         
+        String custom_xml_tags = System.getProperty("custom_xml_tags");  
+
+        if (sr.getScenario() != null){
+            List<String> tags = sr.getScenario().getTagsEffective().getTags();
+            if (tags.size() > 0 && custom_tags != null && custom_xml_tags != null){
+                properties = doc.createElement("properties");
+                
+                custom_tags = custom_tags.toLowerCase();
+                custom_xml_tags = custom_xml_tags.toLowerCase();
+                String[] custom_tags_ar = custom_tags.split("\\s*,\\s*");
+                String[] custom_xml_tags_ar = custom_xml_tags.split("\\s*,\\s*");
+                int custom_tags_size = custom_tags_ar.length;
+
+                for (String tag : tags) {                        
+                    String[] innerTags = tag.split("=");
+                    int size = innerTags.length;
+                    Element requirement = doc.createElement("property");
+                    boolean add_element = false;
+                    
+                    for (int i=0;i<custom_tags_size;i++){
+                        if(custom_tags_ar[i].trim().equals(innerTags[0].toLowerCase())){                            
+                            requirement.setAttribute("name", custom_xml_tags_ar[i]);     
+                            add_element = true;                       
+                        }
+                    }
+                    if (size > 1){
+                        requirement.setAttribute("value", innerTags[1]);
+                    }
+                    
+                    if (add_element){
+                        properties.appendChild(requirement);
+                    }
+                }
+            }
+        }
+
+        return properties;
+    }
+
     public static File saveJunitXml(String targetDir, FeatureResult result, String fileName) {
         DecimalFormat formatter = (DecimalFormat) NumberFormat.getNumberInstance(Locale.US);
         formatter.applyPattern("0.######");
@@ -188,6 +231,13 @@ public class ReportUtils {
             } else {
                 stepsHolder = doc.createElement("system-out");
             }
+
+            Element properties = null;
+            properties = addCustomTags(testCase, doc, sr);
+            if(properties != null && properties.getChildNodes().getLength() > 0){
+                testCase.appendChild(properties);
+            }
+            
             testCase.appendChild(stepsHolder);
             stepsHolder.setTextContent(sb.toString());
             xmlString.append(XmlUtils.toString(testCase)).append('\n');

--- a/karate-core/src/test/java/com/intuit/karate/report/ReportUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/report/ReportUtilsTest.java
@@ -2,7 +2,12 @@ package com.intuit.karate.report;
 
 import com.intuit.karate.core.Feature;
 import com.intuit.karate.core.FeatureRuntime;
+import com.intuit.karate.Suite;
+import com.intuit.karate.FileUtils;
+import com.intuit.karate.report.ReportUtils;
 import org.junit.jupiter.api.Test;
+import java.io.File;
+import static org.junit.jupiter.api.Assertions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +26,21 @@ class ReportUtilsTest {
         fr.run();
         Report report = SuiteReports.DEFAULT.featureReport(fr.suite, fr.result);
         report.render("target/report-test");
+    }
+
+    @Test
+    void testCustomTags() {
+        System.setProperty("custom_tags", "test, requirement");
+        System.setProperty("custom_xml_tags", "test_key, requirement");
+
+        String expectedCustomTags = "<properties><property name=\"requirement\" value=\"CALC-2\"/><property name=\"test_key\" value=\"CALC-2\"/></properties>";
+        Feature feature = Feature.read("classpath:com/intuit/karate/report/customTags.feature");
+        FeatureRuntime fr = FeatureRuntime.of(new Suite(), feature);
+        fr.run();
+        File file = ReportUtils.saveJunitXml("target", fr.result, null);
+        System.out.println("XRAYFILE: " + FileUtils.toString(file));
+        System.out.println("XRAYCUSTOM: " + expectedCustomTags);
+        assertTrue(FileUtils.toString(file).contains(expectedCustomTags));
     }
 
 }

--- a/karate-core/src/test/java/com/intuit/karate/report/ReportUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/report/ReportUtilsTest.java
@@ -30,16 +30,12 @@ class ReportUtilsTest {
 
     @Test
     void testCustomTags() {
-        System.setProperty("custom_tags", "test, requirement");
-        System.setProperty("custom_xml_tags", "test_key, requirement");
-
         String expectedCustomTags = "<properties><property name=\"requirement\" value=\"CALC-2\"/><property name=\"test_key\" value=\"CALC-2\"/></properties>";
         Feature feature = Feature.read("classpath:com/intuit/karate/report/customTags.feature");
         FeatureRuntime fr = FeatureRuntime.of(new Suite(), feature);
         fr.run();
         File file = ReportUtils.saveJunitXml("target", fr.result, null);
-        System.out.println("XRAYFILE: " + FileUtils.toString(file));
-        System.out.println("XRAYCUSTOM: " + expectedCustomTags);
+        
         assertTrue(FileUtils.toString(file).contains(expectedCustomTags));
     }
 

--- a/karate-core/src/test/java/com/intuit/karate/report/customTags.feature
+++ b/karate-core/src/test/java/com/intuit/karate/report/customTags.feature
@@ -1,6 +1,6 @@
 Feature: Cusotm tags
 
 @requirement=CALC-2
-@test=CALC-2
+@test_key=CALC-2
 Scenario:
 * print 'cusomt tags are present in xml'

--- a/karate-core/src/test/java/com/intuit/karate/report/customTags.feature
+++ b/karate-core/src/test/java/com/intuit/karate/report/customTags.feature
@@ -1,0 +1,6 @@
+Feature: Cusotm tags
+
+@requirement=CALC-2
+@test=CALC-2
+Scenario:
+* print 'cusomt tags are present in xml'

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/KarateJunitTest.java
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/KarateJunitTest.java
@@ -4,6 +4,7 @@ import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
 import static org.junit.Assert.*;
 import org.junit.Test;
+import org.junit.BeforeClass;
 
 /**
  *
@@ -11,6 +12,12 @@ import org.junit.Test;
  */
 public class KarateJunitTest {
     
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("custom_tags", "test, requirement");
+        System.setProperty("custom_xml_tags", "test_key, requirement");
+    }
+
     @Test
     public void testAll() {
         Results results = Runner
@@ -18,6 +25,15 @@ public class KarateJunitTest {
                 .path("classpath:com/intuit/karate/junit4/files")
                 .path("classpath:com/intuit/karate/junit4/xml")
                 .parallel(5);
+        assertEquals(results.getErrorMessages(), 0, results.getFailCount());
+    }    
+
+    @Test
+    public void testCustomTags() {
+        Results results = Runner
+                .path("classpath:com/intuit/karate/junit4/customTags")
+                .outputJunitXml(true)
+                .parallel(1);
         assertEquals(results.getErrorMessages(), 0, results.getFailCount());
     }    
     

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/customTags/CustomTagsRunner.java
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/customTags/CustomTagsRunner.java
@@ -1,0 +1,11 @@
+package com.intuit.karate.junit4.files;
+
+import com.intuit.karate.junit4.Karate;
+import com.intuit.karate.KarateOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+@KarateOptions(features = "classpath:com/intuit/karate/junit4/tags/customTags.feature")
+public class CustomTagsRunner {
+
+}

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/customTags/customTags.feature
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/customTags/customTags.feature
@@ -1,0 +1,22 @@
+Feature: custom tags
+
+@requirement=CALC-2
+@test=CALC-2
+Scenario: custom tags are present in xml
+    * print 'xray'
+
+@requirement=CALC-3
+Scenario: xray link to requirement
+  * print 'xray simple requirement'
+
+
+@test=CALC-4
+Scenario: xray link to test
+  * print 'xray simple test'
+
+Scenario: no tags
+  * print 'without additional tags'
+
+@test_tag=CALC-5
+Scenario: invalid tags
+  * print 'with invalid tags'

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/customTags/customTags.feature
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/customTags/customTags.feature
@@ -1,7 +1,7 @@
 Feature: custom tags
 
 @requirement=CALC-2
-@test=CALC-2
+@test_key=CALC-2
 Scenario: custom tags are present in xml
     * print 'xray'
 
@@ -10,13 +10,10 @@ Scenario: xray link to requirement
   * print 'xray simple requirement'
 
 
-@test=CALC-4
+@test_key=CALC-4
 Scenario: xray link to test
   * print 'xray simple test'
 
 Scenario: no tags
   * print 'without additional tags'
 
-@test_tag=CALC-5
-Scenario: invalid tags
-  * print 'with invalid tags'

--- a/karate-junit5/src/test/java/karate/SampleCustomTagsTest.java
+++ b/karate-junit5/src/test/java/karate/SampleCustomTagsTest.java
@@ -1,17 +1,10 @@
 package karate;
 
 import com.intuit.karate.junit5.Karate;
-import org.junit.jupiter.api.BeforeEach;
 import com.intuit.karate.Results;
 
 
 class SampleCustomTagsTest {
-    
-    @BeforeEach
-    void beforeEach() {
-        System.setProperty("custom_tags", "test, requirement");
-        System.setProperty("custom_xml_tags", "test_key, requirement");
-    }
 
     @Karate.Test
     Karate testXrayTags() {

--- a/karate-junit5/src/test/java/karate/SampleCustomTagsTest.java
+++ b/karate-junit5/src/test/java/karate/SampleCustomTagsTest.java
@@ -1,0 +1,20 @@
+package karate;
+
+import com.intuit.karate.junit5.Karate;
+import org.junit.jupiter.api.BeforeEach;
+import com.intuit.karate.Results;
+
+
+class SampleCustomTagsTest {
+    
+    @BeforeEach
+    void beforeEach() {
+        System.setProperty("custom_tags", "test, requirement");
+        System.setProperty("custom_xml_tags", "test_key, requirement");
+    }
+
+    @Karate.Test
+    Karate testXrayTags() {
+        return Karate.run("classpath:karate/customTags.feature").outputJunitXml(true);
+    }
+}

--- a/karate-junit5/src/test/java/karate/customTags.feature
+++ b/karate-junit5/src/test/java/karate/customTags.feature
@@ -1,23 +1,24 @@
 Feature: cusotm tags test
 
+@first
 @requirement=CALC-2
-@test=CALC-2
+@test_key=CALC-2
 Scenario: xray simple scenario
   * print 'xray simple example'
 
+@second
 @requirement=CALC-3
 Scenario: xray link to requirement
   * print 'xray simple requirement'
 
 
+@third
 @test=CALC-4
 Scenario: xray link to test
   * print 'xray simple test'
 
+@fourth
 Scenario: no tags
   * print 'without additional tags'
 
-@test_tag=CALC-5
-Scenario: invalid tags
-  * print 'with invalid tags'
 

--- a/karate-junit5/src/test/java/karate/customTags.feature
+++ b/karate-junit5/src/test/java/karate/customTags.feature
@@ -1,0 +1,23 @@
+Feature: cusotm tags test
+
+@requirement=CALC-2
+@test=CALC-2
+Scenario: xray simple scenario
+  * print 'xray simple example'
+
+@requirement=CALC-3
+Scenario: xray link to requirement
+  * print 'xray simple requirement'
+
+
+@test=CALC-4
+Scenario: xray link to test
+  * print 'xray simple test'
+
+Scenario: no tags
+  * print 'without additional tags'
+
+@test_tag=CALC-5
+Scenario: invalid tags
+  * print 'with invalid tags'
+


### PR DESCRIPTION
Xray integration #1902

### Description

Code to enable the addition of custom Junit tags in the scenarios that will generate a <properties> element in the XML report.

Set custom tags in env variables: 
```
@BeforeClass
    public static void beforeClass() {
        System.setProperty("custom_tags", "test, requirement");
        System.setProperty("custom_xml_tags", "test_key, requirement");
    }
```

Use them in the Scenarios:
```
@requirement=CALC-2
@test=CALC-2
Scenario: custom tags are present in xml
    * print 'xray'
```

And it will generate a new XML Element in the report:
`<properties><property name="requirement" value="CALC-2"/><property name="test_key" value="CALC-2"/></properties>
`
- Relevant Issues : #1902 
- Relevant PRs : (optional)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
