### PR TITLE
Upgrade snakeyaml from 1.29 to 1.31 fixing CVE-2022-25857

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.29</version>
+            <version>1.31</version>
         </dependency>
         <dependency>
             <groupId>de.siegmar</groupId>


### PR DESCRIPTION
The upgrade fixes a Denial of Service (DoS) vulnerability
caused by a missing nested depth limitation for collections.

https://nvd.nist.gov/vuln/detail/CVE-2022-25857

### Description

- Relevant Issues : #2116
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
