### PR TITLE
Graal 21.3.4 fixing 18 vulnerabilities

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -12,7 +12,7 @@
     
     <properties>
         <antlr.version>4.9.2</antlr.version>
-        <graal.version>21.2.0</graal.version>
+        <graal.version>21.3.4</graal.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Upgrade Graal from 21.2.0 to 21.3.4.
This fixes 18 vulnerabilities in org.graalvm.sdk:graal-sdk: https://security.snyk.io/package/maven/org.graalvm.sdk:graal-sdk/21.2.0

This pull request is against the master branch because the development branch is already at 22.0.0.2.