### PR TITLE
Switch to root session on page close

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -449,6 +449,7 @@ public abstract class DevToolsDriver implements Driver {
     @Override
     public void close() {
         method("Page.close").sendWithoutWaiting();
+        sessionId = frameSessions.get(rootFrameId);
     }
 
     @Override

--- a/karate-e2e-tests/src/test/java/driver/00.feature
+++ b/karate-e2e-tests/src/test/java/driver/00.feature
@@ -56,3 +56,6 @@ Scenario:
 
 # image comparison
 * if (!skipSlowTests) karate.call('16.feature')
+
+# switch to root session on page close
+* call read('17.feature')

--- a/karate-e2e-tests/src/test/java/driver/17.feature
+++ b/karate-e2e-tests/src/test/java/driver/17.feature
@@ -1,0 +1,17 @@
+Feature:
+
+  Background:
+    * driver serverUrl + '/17_a'
+
+  Scenario:
+    * def openPageInNewTab = (pageUrl) => driver.script(`window.open('${pageUrl}', '_blank', 'noopener')`)
+
+    * waitFor('input[name=a]').input('a1')
+
+    * openPageInNewTab(serverUrl + '/17_b')
+    * switchPage('17_b')
+    * waitFor('input[name=b]').input('b1')
+    * close()
+
+    * switchPage('17_a')
+    * input('input[name=a]', 'a2')

--- a/karate-e2e-tests/src/test/java/driver/html/17_a.html
+++ b/karate-e2e-tests/src/test/java/driver/html/17_a.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+    <title>Page 17_a</title>
+    <link rel="stylesheet" href="00.css" type="text/css"/>
+    <link rel="icon" href="00.ico">
+</head>
+<body>
+<input type="text" name="a">
+</body>
+</html>

--- a/karate-e2e-tests/src/test/java/driver/html/17_b.html
+++ b/karate-e2e-tests/src/test/java/driver/html/17_b.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+    <title>Page 17_b</title>
+    <link rel="stylesheet" href="00.css" type="text/css"/>
+    <link rel="icon" href="00.ico">
+</head>
+<body>
+<input type="text" name="b">
+</body>
+</html>


### PR DESCRIPTION
### Description

This PR fixes an issue with the DevToolsDriver where we continued to use a destroyed sessionId after the page was closed.

- Relevant Issues : https://github.com/karatelabs/karate/issues/2032
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
