### PR TITLE
fix bug preventing 'Transparent' button from updating image diff UI

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/report/karate-report.js
+++ b/karate-core/src/main/java/com/intuit/karate/report/karate-report.js
@@ -88,7 +88,7 @@ function newDiffUI(targetElement, diffResult, diffConfig, onShowRebase, onShowCo
         .repaint()
     } else if ($this.hasClass('opaque')) {
       resembleControl.outputSettings({ transparency: 1 }).repaint()
-    } else if ($this.is('transparent')) {
+    } else if ($this.hasClass('transparent')) {
       resembleControl.outputSettings({ transparency: 0.3 }).repaint()
     }
   })


### PR DESCRIPTION
### Description

This PR fixes a bug in the image comparison UI that prevented the `Transparent` button from updating the image diff.

- Relevant Issues : https://github.com/karatelabs/karate/issues/2141
- Relevant PRs : https://github.com/karatelabs/karate/pull/2153
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
