### PR TITLE
improve HTML report loading performance

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Embed.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Embed.java
@@ -98,7 +98,9 @@ public class Embed {
         } else if (resourceType.isImage()) {
             return "<img src=\"" + file.getName() + "\"/>";
         } else if (resourceType.isScript()) {
-            return "<script type=\"text/javascript\" src=\"" + file.getName() + "\"></script>";
+            return resourceType == ResourceType.DEFERRED_JS ?
+                    "<div data-deferred=\"true\" data-src=\"" + file.getName() + "\">Loading...</div>" :
+                    "<script type=\"text/javascript\" src=\"" + file.getName() + "\"></script>";
         } else {
             return "<a href=\"" + file.getName() + "\">" + file.getName() + "</a>";
         }

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -1080,7 +1080,7 @@ public class ScenarioEngine {
                         getImageHookFunction(options, defaultOptions, "onShowConfig") +
                         ")";
 
-                runtime.embed(JsValue.toBytes(diffJS), ResourceType.JS);
+                runtime.embed(JsValue.toBytes(diffJS), ResourceType.DEFERRED_JS);
             }
         }
 

--- a/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
@@ -34,6 +34,7 @@ import org.w3c.dom.Node;
  */
 public enum ResourceType {
 
+    DEFERRED_JS("text/javascript", vals("javascript"), vals("js")),
     JS("text/javascript", vals("javascript"), vals("js")),
     JSON("application/json", vals("json"), vals("json")),
     CSS("text/css", vals("css"), vals("css")),
@@ -175,7 +176,13 @@ public enum ResourceType {
     }
 
     public boolean isScript() {
-        return this == ResourceType.JS;
+        switch (this){
+            case JS:
+            case DEFERRED_JS:
+                return true;
+            default:
+                return false;
+        }
     }
 
     public static ResourceType fromContentType(String ct) {

--- a/karate-core/src/main/java/com/intuit/karate/report/karate-report.js
+++ b/karate-core/src/main/java/com/intuit/karate/report/karate-report.js
@@ -1,14 +1,31 @@
 window.onload = function () {
-  $('div.step-container').each(function (i) {
-    var id = this.id;
-    var children = $("[data-parent='" + id + "']");
-    if (children.length > 0) {
-      children.hide('fast');
-      $(this).wrap("<a href='javascript:void(0)'></a>").click(function () {
-        children.toggle('fast');
-      });
-    }
-  });
+  const parentIds = {}
+
+  document.querySelectorAll('[data-parent]').forEach(child => {
+    parentIds[child.dataset.parent] = true
+    child.style.display = 'none'
+  })
+
+  document.querySelectorAll('div.step-container').forEach(parent => {
+    if (!parentIds[parent.id]) return
+    const link = document.createElement('a')
+    link.dataset.stepId = parent.id
+    link.href = 'javascript:void()'
+    parent.parentNode.insertBefore(link, parent)
+    link.appendChild(parent)
+  })
+
+  $('#content').on('click', 'a[data-step-id]', function () {
+    const parentId = $(this).data('step-id')
+    $(`[data-parent='${parentId}']`).toggle('fast')
+    $(`[data-parent='${parentId}'] [data-deferred]`).each((i, deferred) => {
+      const script = document.createElement('script')
+      script.type = 'text/javascript'
+      script.src = deferred.dataset.src
+      deferred.parentNode.replaceChild(script, deferred)
+    })
+  })
+
   $("table.features-table").tablesorter();
   $("table.tags-table").tablesorter();
 };
@@ -219,7 +236,7 @@ function newDiffUI(targetElement, diffResult, diffConfig, onShowRebase, onShowCo
   })
 
   // wait for step contents animation to complete and then execute the diff
-  $el.closest('.embed').parent().one('click', () => setTimeout(compareImg, 300))
+  setTimeout(compareImg, 300)
 
 
   // -- begin helper function definitions -- \\


### PR DESCRIPTION
### Description

This PR improves the loading performance for HTML reports.
Anecdotally, our largest features would refuse to load even after 20 minutes. After this change, they load in 5-10 seconds.

There are three main areas of improvement:
1. use vanilla JS in hot paths (since jQuery can sometimes be a bit slow)
2. utilize event delegation to avoid adding unneeded event listeners
3. defer loading / processing wherever possible (specifically, when identifying step child nodes during toggling and loading image comparison diff UI options lazily)

- Relevant Issues : https://github.com/karatelabs/karate/issues/1270
- Relevant PRs : n/a
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
