### PR TITLE
improve Result details for http failure

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -609,7 +609,7 @@ public class ScenarioEngine {
                 PerfEvent pe = new PerfEvent(startTime, endTime, perfEventName, 0);
                 capturePerfEvent(pe); // failure flag and message should be set by logLastPerfEvent()
             }
-            throw new KarateException(message, e);
+            throw new KarateException(message + "\n" + e.getMessage(), e);
         }
         startTime = httpRequest.getStartTime(); // in case it was re-adjusted by http client
         final long endTime = httpRequest.getEndTime();


### PR DESCRIPTION
 Added http exception message to karate exception so it appears in Result as well 
 https://github.com/karatelabs/karate/issues/2216

### Description

This PR improves the way Result is passed on in case of http failures. by adding the actual cause to it 

- Relevant Issues : (https://github.com/karatelabs/karate/issues/2216)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
