### PR TITLE
Upgrade snakeyaml from 1.33 to 2.0 fixing CVE-2022-1471

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>de.siegmar</groupId>

--- a/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
@@ -49,6 +49,7 @@ import net.minidev.json.JSONValue;
 import net.minidev.json.parser.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -159,7 +160,7 @@ public class JsonUtils {
     }
 
     public static Object fromYaml(String raw) {
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         return yaml.load(raw);
     }
 


### PR DESCRIPTION
Snakeyaml 2.0 has a fix for the CVE-2022-1471 Arbitrary Code Execution vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-1471
https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes

Karate is not affected by this vulnerability, but other code might be so that Karate should be compatible with Snakeyaml 2.0 and by default should ship with Snakeyaml 2.0.

The JsonUtils code change is required for 2.0 but also works in 1.33 so that projects that use latest Karate may manually downgrade Snakeyaml from 2.0 to 1.33 if needed.

### Description

- Relevant Issues : #2265
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
