### PR TITLE
Fix #2324 - karate.callSingle caching fails on Windows using different keys

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/StringUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/StringUtils.java
@@ -173,10 +173,10 @@ public class StringUtils {
         if (name == null) {
             return "";
         }
-        return name.replaceAll("[\\s_\\\\/:]", "-").toLowerCase();
+        return name.replaceAll("[\\s_\\\\/:<>\"\\|\\?\\*]", "-").toLowerCase();
     }
 
-    public static StringUtils.Pair splitByFirstLineFeed(String text) {
+public static StringUtils.Pair splitByFirstLineFeed(String text) {
         String left = "";
         String right = "";
         if (text != null) {

--- a/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
@@ -96,6 +96,11 @@ class StringUtilsTest {
         assertEquals("foo--bar", StringUtils.toIdString("foo//bar"));
         assertEquals("foo-bar", StringUtils.toIdString("foo\\bar"));
         assertEquals("foo-bar", StringUtils.toIdString("foo:bar"));
+        assertEquals("foo-bar", StringUtils.toIdString("foo?bar"));
+        assertEquals("foo-bar", StringUtils.toIdString("foo\"bar"));
+        assertEquals("foo-bar", StringUtils.toIdString("foo*bar"));
+        assertEquals("foo-bar", StringUtils.toIdString("foo|bar"));
+        assertEquals("foo--bar", StringUtils.toIdString("foo<>bar"));
         assertEquals("", StringUtils.toIdString(null)); // TODO
     }
 


### PR DESCRIPTION
Remove Windows filename reserved chars (<>:"/|?*)

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : #2324 
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
