### PR TITLE
FIx compatibility for cucumber java plugin

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -71,6 +71,25 @@
             <version>2.8.0</version>
         </dependency>
         <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>1.2.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>info.cukes</groupId>
+                    <artifactId>cucumber-html</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>info.cukes</groupId>
+                    <artifactId>cucumber-jvm-deps</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>info.cukes</groupId>
+                    <artifactId>gherkin</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
             <version>2.4.10</version>

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -71,25 +71,6 @@
             <version>2.8.0</version>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
-            <artifactId>cucumber-java</artifactId>
-            <version>1.2.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>info.cukes</groupId>
-                    <artifactId>cucumber-html</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>info.cukes</groupId>
-                    <artifactId>cucumber-jvm-deps</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>info.cukes</groupId>
-                    <artifactId>gherkin</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
             <version>2.4.10</version>

--- a/karate-core/src/main/java/com/intuit/karate/ScenarioActions.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScenarioActions.java
@@ -26,7 +26,8 @@ package com.intuit.karate;
 import com.intuit.karate.core.AssignType;
 import com.intuit.karate.core.Action;
 import com.intuit.karate.core.ScenarioEngine;
-import com.intuit.karate.core.When;
+import cucumber.api.DataTable;
+import cucumber.api.java.en.When;
 import java.util.List;
 import java.util.Map;
 
@@ -153,14 +154,24 @@ public class ScenarioActions implements Actions {
         engine.request(body);
     }
 
-    @Override
     @When("^table (.+)")
+    public void table(String name, DataTable table) {
+        table(name, table.asMaps(String.class, String.class));
+    }
+
+    @Override
+    @Action("^table (.+)")
     public void table(String name, List<Map<String, String>> table) {
         engine.table(name, table);
     }
 
-    @Override
     @When("^replace (\\w+)$")
+    public void replace(String name, DataTable table) {
+        replace(name, table.asMaps(String.class, String.class));
+    }
+
+    @Override
+    @Action("^replace (\\w+)$")
     public void replace(String name, List<Map<String, String>> table) {
         engine.replaceTable(name, table);
     }
@@ -176,7 +187,7 @@ public class ScenarioActions implements Actions {
     public void def(String name, String exp) {
         engine.assign(AssignType.AUTO, name, exp, false);
     }
-    
+
     @Override
     @When("^def (.+) =$")
     public void defDocString(String name, String exp) {
@@ -194,12 +205,12 @@ public class ScenarioActions implements Actions {
     public void yaml(String name, String exp) {
         engine.assign(AssignType.YAML, name, exp, false);
     }
-    
+
     @Override
     @When("^yaml (.+) =$")
     public void yamlDocString(String name, String exp) {
         engine.assign(AssignType.YAML, name, exp, true);
-    }    
+    }
 
     @Override
     @When("^copy (.+) = (.+)")
@@ -330,8 +341,13 @@ public class ScenarioActions implements Actions {
         engine.set(name, path, value);
     }
 
-    @Override
     @When("^set ([^\\s]+)( [^=]+)?$")
+    public void set(String name, String path, DataTable table) {
+        set(name, path, table.asMaps(String.class, String.class));
+    }
+
+    @Override
+    @Action("^set ([^\\s]+)( [^=]+)?$")
     public void set(String name, String path, List<Map<String, String>> table) {
         engine.setViaTable(name, path, table);
     }

--- a/karate-core/src/main/java/com/intuit/karate/core/StepRuntime.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/StepRuntime.java
@@ -29,6 +29,7 @@ import com.intuit.karate.JsonUtils;
 import com.intuit.karate.KarateException;
 import com.intuit.karate.ScenarioActions;
 import com.intuit.karate.StringUtils;
+import cucumber.api.java.en.When;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/karate-core/src/main/java/com/intuit/karate/core/StepRuntime.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/StepRuntime.java
@@ -210,6 +210,13 @@ public class StepRuntime {
                 String keyword = method.getName().equalsIgnoreCase("eval") ? "eval" : methodPattern.keyword;
                 Collection<Method> keywordMethods = KEYWORDS_METHODS.computeIfAbsent(keyword, k -> new HashSet<>());
                 keywordMethods.add(methodPattern.method);
+            } else {
+                Action action = method.getDeclaredAnnotation(Action.class);
+                if (action != null) {
+                    String regex = action.value();
+                    MethodPattern methodPattern = new MethodPattern(method, regex);
+                    overwrite.add(methodPattern);
+                }
             }
         }
         for (MethodPattern mp : overwrite) {

--- a/karate-core/src/main/java/cucumber/api/DataTable.java
+++ b/karate-core/src/main/java/cucumber/api/DataTable.java
@@ -1,0 +1,18 @@
+package cucumber.api;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * replaces cucumber-jvm code
+ * 
+ * @author pthomas3
+ */
+public class DataTable {
+    
+    public List<Map<String, String>> asMaps(Class<String> keyType, Class<String> valType) {
+        return Collections.EMPTY_LIST;
+    }
+    
+}

--- a/karate-core/src/main/java/cucumber/api/cli/Main.java
+++ b/karate-core/src/main/java/cucumber/api/cli/Main.java
@@ -1,0 +1,15 @@
+package cucumber.api.cli;
+
+/**
+ * replaces cucumber-jvm code
+ *
+ * @author pthomas3
+ */
+public class Main {
+
+    public static void main(String[] args) {
+        com.intuit.karate.cli.IdeMain.main(args);
+        System.exit(0);
+    }
+
+}

--- a/karate-core/src/main/java/cucumber/api/java/en/When.java
+++ b/karate-core/src/main/java/cucumber/api/java/en/When.java
@@ -1,4 +1,4 @@
-package com.intuit.karate.core;
+package cucumber.api.java.en;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
@@ -1,5 +1,6 @@
 package com.intuit.karate.core;
 
+import cucumber.api.java.en.When;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;


### PR DESCRIPTION
### Description

Reverts refactor of @When annotation to support cucumber java plugin so that all step definitions are not treated as warnings.

Until this is addressed, I'll need to maintain a fork for our use since we have finite karate plugin licenses and we need a java debugger. 

- Relevant Issues : https://github.com/karatelabs/karate/issues/2327, https://github.com/karatelabs/karate-intellij-plugin/issues/30
- Relevant PRs :
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

All that would be needed for users to use cucumber java plugin would be to add jar dependency to their own project
`<dependency>
            <groupId>info.cukes</groupId>
            <artifactId>cucumber-java</artifactId>
            <version>1.2.5</version>
            <exclusions>
                <exclusion>
                    <groupId>info.cukes</groupId>
                    <artifactId>cucumber-html</artifactId>
                </exclusion>
                <exclusion>
                    <groupId>info.cukes</groupId>
                    <artifactId>cucumber-jvm-deps</artifactId>
                </exclusion>
                <exclusion>
                    <groupId>info.cukes</groupId>
                    <artifactId>gherkin</artifactId>
                </exclusion>
            </exclusions>
        </dependency>`
