### PR TITLE
add support for NTLM authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -2270,6 +2270,7 @@ You can adjust configuration settings for the HTTP client used by Karate using t
 `pauseIfNotPerf` | boolean | defaults to `false`, relevant only for performance-testing, see [`karate.pause()`](#karate-pause) and [`karate-gatling`](karate-gatling#think-time)
 `xmlNamespaceAware` | boolean | defaults to `false`, to handle XML namespaces in [some special circumstances](https://github.com/karatelabs/karate/issues/1587)
 `abortSuiteOnFailure` | boolean | defaults to `false`, to not attempt to run any more tests upon a failure
+`ntlmAuthentication` | JSON | See [NTLM Authentication](#ntlm-authentication)
 
 Examples:
 ```cucumber
@@ -2407,6 +2408,33 @@ karate.configure('ssl', { trustAll: true });
 ```
 
 For end-to-end examples in the Karate demos, look at the files in [this folder](karate-demo/src/test/java/ssl).
+
+### NTLM Authentication
+Karate provides support for NTLM authentication using the Apache NTLMEngine implementation.
+
+| Key           | Type   | Required? | Description                                                    |
+|---------------|--------|-----------|----------------------------------------------------------------|
+| `username`    | string | required  | NTLM username                                                  |
+| `password`    | string | required  | NTLM password                                                  |
+| `workstation` | string | optional  | The workstation the authentication request is originating from |
+| `domain`      | string | optional  | The domain to authenticate within                              |
+
+Example:
+```cucumber
+# enable NTLM authentication for the remaining scenario requests
+* configure ntlmAuthentication = { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'my-pc' }
+
+# enable NTLM authentication with only credentials
+* configure ntlmAuthentication = { username: 'admin', password: 'secret' }
+
+# disable NTLM authentication
+* configure ntlmAuthentication = null
+```
+
+```js
+// enable NTLM authentication within js
+karate.confgure('ntlmAuthentication', { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'my-pc' })
+```
 
 # Payload Assertions
 ## Prepare, Mutate, Assert.

--- a/README.md
+++ b/README.md
@@ -2270,7 +2270,7 @@ You can adjust configuration settings for the HTTP client used by Karate using t
 `pauseIfNotPerf` | boolean | defaults to `false`, relevant only for performance-testing, see [`karate.pause()`](#karate-pause) and [`karate-gatling`](karate-gatling#think-time)
 `xmlNamespaceAware` | boolean | defaults to `false`, to handle XML namespaces in [some special circumstances](https://github.com/karatelabs/karate/issues/1587)
 `abortSuiteOnFailure` | boolean | defaults to `false`, to not attempt to run any more tests upon a failure
-`ntlmAuthentication` | JSON | See [NTLM Authentication](#ntlm-authentication)
+`ntlmAuth` | JSON | See [NTLM Authentication](#ntlm-authentication)
 
 Examples:
 ```cucumber
@@ -2422,18 +2422,18 @@ Karate provides support for NTLM authentication using the Apache NTLMEngine impl
 Example:
 ```cucumber
 # enable NTLM authentication for the remaining scenario requests
-* configure ntlmAuthentication = { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'my-pc' }
+* configure ntlmAuth = { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'my-pc' }
 
 # enable NTLM authentication with only credentials
-* configure ntlmAuthentication = { username: 'admin', password: 'secret' }
+* configure ntlmAuth = { username: 'admin', password: 'secret' }
 
 # disable NTLM authentication
-* configure ntlmAuthentication = null
+* configure ntlmAuth = null
 ```
 
 ```js
 // enable NTLM authentication within js
-karate.confgure('ntlmAuthentication', { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'my-pc' })
+karate.confgure('ntlmAuth', { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'my-pc' })
 ```
 
 # Payload Assertions

--- a/karate-core/src/main/java/com/intuit/karate/core/Config.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Config.java
@@ -108,6 +108,13 @@ public class Config {
     // image comparison config
     private Map<String, Object> imageComparisonOptions;
 
+    // ntlm authentication
+    private boolean ntlmEnabled = false;
+    private String ntlmUsername;
+    private String ntlmPassword;
+    private String ntlmDomain;
+    private String ntlmWorkstation;
+
     public Config() {
         // zero arg constructor
     }
@@ -299,6 +306,18 @@ public class Config {
             case "localAddress":
                 localAddress = value.getAsString();
                 return true;
+            case "ntlmAuthentication":
+                if (value.isNull()) {
+                    ntlmEnabled = false;
+                } else {
+                    Map<String, Object> map = value.getValue();
+                    ntlmEnabled = true;
+                    ntlmUsername = (String) map.get("username");
+                    ntlmPassword = (String) map.get("password");
+                    ntlmDomain = (String) map.get("domain");
+                    ntlmWorkstation = (String) map.get("workstation");
+                }
+                return true;
             default:
                 throw new RuntimeException("unexpected 'configure' key: '" + key + "'");
         }
@@ -352,6 +371,11 @@ public class Config {
         continueAfterContinueOnStepFailure = parent.continueAfterContinueOnStepFailure;
         abortSuiteOnFailure = parent.abortSuiteOnFailure;
         imageComparisonOptions = parent.imageComparisonOptions;
+        ntlmEnabled = parent.ntlmEnabled;
+        ntlmUsername = parent.ntlmUsername;
+        ntlmPassword = parent.ntlmPassword;
+        ntlmDomain = parent.ntlmDomain;
+        ntlmWorkstation = parent.ntlmWorkstation;
     }
 
     public void setUrl(String url) {
@@ -588,6 +612,46 @@ public class Config {
 
     public Map<String, Object> getImageComparisonOptions() {
         return imageComparisonOptions;
+    }
+
+    public boolean isNtlmEnabled() {
+        return ntlmEnabled;
+    }
+
+    public void setNtlmEnabled(boolean ntlmEnabled) {
+        this.ntlmEnabled = ntlmEnabled;
+    }
+
+    public String getNtlmUsername() {
+        return ntlmUsername;
+    }
+
+    public void setNtlmUsername(String ntlmUsername) {
+        this.ntlmUsername = ntlmUsername;
+    }
+
+    public String getNtlmPassword() {
+        return ntlmPassword;
+    }
+
+    public void setNtlmPassword(String ntlmPassword) {
+        this.ntlmPassword = ntlmPassword;
+    }
+
+    public String getNtlmDomain() {
+        return ntlmDomain;
+    }
+
+    public void setNtlmDomain(String ntlmDomain) {
+        this.ntlmDomain = ntlmDomain;
+    }
+
+    public String getNtlmWorkstation() {
+        return ntlmWorkstation;
+    }
+
+    public void setNtlmWorkstation(String ntlmWorkstation) {
+        this.ntlmWorkstation = ntlmWorkstation;
     }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/core/Config.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Config.java
@@ -306,7 +306,7 @@ public class Config {
             case "localAddress":
                 localAddress = value.getAsString();
                 return true;
-            case "ntlmAuthentication":
+            case "ntlmAuth":
                 if (value.isNull()) {
                     ntlmEnabled = false;
                 } else {

--- a/karate-core/src/main/java/com/intuit/karate/http/ApacheHttpClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/ApacheHttpClient.java
@@ -55,10 +55,12 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpMessage;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.EntityBuilder;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -191,6 +193,16 @@ public class ApacheHttpClient implements HttpClient, HttpRequestInterceptor {
             } catch (Exception e) {
                 logger.warn("failed to resolve local address: {} - {}", config.getLocalAddress(), e.getMessage());
             }
+        }
+        if (config.isNtlmEnabled()) {
+            List<String> authSchemes = new ArrayList<>();
+            authSchemes.add(AuthSchemes.NTLM);
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            NTCredentials ntCredentials = new NTCredentials(
+                config.getNtlmUsername(), config.getNtlmPassword(), config.getNtlmWorkstation(), config.getNtlmDomain());
+            credentialsProvider.setCredentials(AuthScope.ANY, ntCredentials);
+            clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+            configBuilder.setTargetPreferredAuthSchemes(authSchemes);
         }
         clientBuilder.setDefaultRequestConfig(configBuilder.build());
         SocketConfig.Builder socketBuilder = SocketConfig.custom().setSoTimeout(config.getConnectTimeout());

--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
@@ -399,6 +399,11 @@ class FeatureRuntimeTest {
     @Test
     void testTypeConv() {
         run("type-conv.feature");
-    }     
+    }
+
+    @Test
+    void testConfigureNtlmAuthentication() {
+        run("ntlm-authentication.feature");
+    }
 
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/ntlm-authentication.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/ntlm-authentication.feature
@@ -1,0 +1,10 @@
+Feature: ntlm authentication
+
+  Scenario: various ways to configure ntlm authentication
+    * configure ntlmAuthentication = { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'ws' }
+    * configure ntlmAuthentication = { username: 'admin', password: 'secret' }
+    * configure ntlmAuthentication = null
+    * eval
+    """
+    karate.configure('ntlmAuthentication', { username: 'admin', password: 'secret' })
+    """

--- a/karate-core/src/test/java/com/intuit/karate/core/ntlm-authentication.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/ntlm-authentication.feature
@@ -1,10 +1,10 @@
 Feature: ntlm authentication
 
   Scenario: various ways to configure ntlm authentication
-    * configure ntlmAuthentication = { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'ws' }
-    * configure ntlmAuthentication = { username: 'admin', password: 'secret' }
-    * configure ntlmAuthentication = null
+    * configure ntlmAuth = { username: 'admin', password: 'secret', domain: 'my.domain', workstation: 'my-pc' }
+    * configure ntlmAuth = { username: 'admin', password: 'secret' }
+    * configure ntlmAuth = null
     * eval
     """
-    karate.configure('ntlmAuthentication', { username: 'admin', password: 'secret' })
+    karate.configure('ntlmAuth', { username: 'admin', password: 'secret' })
     """


### PR DESCRIPTION
### Description

This adds support for NTLM authentication through the ApacheHttpClient implementation. It takes advantage of the default AuthSchemeRegistry that the builder creates when none is supplied, which includes support for NTLM. And so, supplying the NT credentials and target auth scheme will activate it within the http client from the config.

Unfortunately, the tests are quite limited since a true test would require an environment with an LDAP setup and a system configured with NTLM auth. I couldn't find anything readily available to support that, so I have only included a test for configuring NTLM within a Karate script and tested it against a valid NTLM system within my org locally.

- Relevant Issues : #372
- Relevant PRs : N/A
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

