### PR TITLE
Fix flaky test KarateHttpMockHandlerTest.testMultipleCookies

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/TestUtils.java
+++ b/karate-core/src/test/java/com/intuit/karate/TestUtils.java
@@ -32,6 +32,12 @@ public class TestUtils {
         assertTrue(mr.pass, mr.message);
     }
 
+    public static void matchContainsEither(Object actual, Object expected1, Object expected2) {
+        Match.Result mr1 = Match.evaluate(actual).contains(expected1);
+        Match.Result mr2 = Match.evaluate(actual).contains(expected2);
+        assertTrue(mr1.pass || mr2.pass, mr1.message);
+    }
+
     public static ScenarioEngine engine() {
         return new ScenarioEngine(new Config(), runtime(), new HashMap(), new Logger());
     }

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
@@ -55,6 +55,10 @@ class KarateHttpMockHandlerTest {
         matchContains(get(name), expected);
     }
 
+    private void matchVarContainsEither(String name, Object expected1, Object expected2) {
+        matchContainsEither(get(name), expected1, expected2);
+    }
+
     @AfterEach
     void afterEach() {
         server.stop();
@@ -162,7 +166,7 @@ class KarateHttpMockHandlerTest {
                 "cookie cookie2 = 'bar'",
                 "method get"
         );
-        matchVarContains("response", "{ cookie: ['cookie1=foo; cookie2=bar'] }");
+        matchVarContainsEither("response", "{ cookie: ['cookie1=foo; cookie2=bar'] }", "{ cookie: ['cookie2=bar; cookie1=foo'] }");
     }
 
     @Test


### PR DESCRIPTION
### Description

The test

`com.intuit.karate.core.KarateHttpMockHandlerTest.testMultipleCookies`

fails under environment [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detects flakiness under non-deterministic data structure usages.

The potential problem is that `cookies` is a HashSet ([reference](https://github.com/karatelabs/karate/blob/master/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java#L441)), whose order is not guaranteed during iteration on different environments.

Quote from [Oracle Java 8 Doc](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html):

> It makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time.

### Reproduce

```
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -pl karate-core -Dtest=intuit.karate.core.KarateHttpMockHandlerTest#testMultipleCookies 
```

- Relevant Issues : potential flaky tests due to non-deterministic cookie object
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

### Proposal

Change the test to so that it works on every non-deterministic order of the HashSet.

The following Continuous Integration log that shows the flakiness of the test:
https://github.com/asha-boyapati/karate/actions/runs/5041250682

The following Continuous Integration log that shows that the flakiness is fixed by this change:
https://github.com/asha-boyapati/karate/actions/runs/5041348913

Note that this proposal only changes test code.  It thus has no effect on non-test code.