### PR TITLE
chore: use fragment expression

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/report/karate-summary.html
+++ b/karate-core/src/main/java/com/intuit/karate/report/karate-summary.html
@@ -25,7 +25,7 @@
             reportDate: results.resultDate
           };
         </script>
-        <div th:replace="karate-leftnav.html"></div>
+        <div th:replace="~{karate-leftnav.html}"></div>
       </div>
       <div id="content">
         <div class="page-heading alert alert-primary">


### PR DESCRIPTION
Running karate with current thymeleaf versions generates a warning:

```
org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor","msg":"[THYMELEAF][main][karate-summary.html] Deprecated unwrapped fragment expression \"karate-leftnav.html\" found in template karate-summary.html, line 28, col 14. Please use the complete syntax of fragment expressions instead (\"~{karate-leftnav.html}\"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
```
 
This PR does as suggested and uses a fragment expression to include the`karate-leftnav`.

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
