### PR TITLE
Use Netty HttpPostRequestEncoder with "HTML5" encoder mode to prevent…

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/MultiPartBuilder.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/MultiPartBuilder.java
@@ -34,7 +34,10 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
 import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
+import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder.EncoderMode;
+import io.netty.util.CharsetUtil;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.codec.http.multipart.MemoryFileUpload;
 import java.io.File;
@@ -92,7 +95,7 @@ public class MultiPartBuilder {
         this.multipart = multipart;
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf("POST"), "/");
         try {
-            encoder = new HttpPostRequestEncoder(request, multipart);
+            encoder = new HttpPostRequestEncoder(new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE), request, multipart, CharsetUtil.UTF_8, EncoderMode.HTML5);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/karate-core/src/test/java/com/intuit/karate/TestUtils.java
+++ b/karate-core/src/test/java/com/intuit/karate/TestUtils.java
@@ -31,6 +31,11 @@ public class TestUtils {
         Match.Result mr = Match.evaluate(actual).contains(expected);
         assertTrue(mr.pass, mr.message);
     }
+    
+    public static void notContains(Object actual, Object expected) {
+        Match.Result mr = Match.evaluate(actual).isNotContaining(expected);
+        assertTrue(mr.pass, mr.message);
+    }
 
     public static ScenarioEngine engine() {
         return new ScenarioEngine(new Config(), runtime(), new HashMap(), new Logger());

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
@@ -391,6 +391,23 @@ class KarateMockHandlerTest {
     }
 
     @Test
+    void testMultiPartFiles() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def response = requestParts");
+        run(
+                URL_STEP,
+                "def file1 = { name: 'file', filename: 'file1.txt', value: 'Hello 1' }", 
+                "def file2 = { name: 'file', filename: 'file2.txt', value: 'Hello 2' }", 
+                "multipart files ([file1, file2])",
+                "path 'hello'",
+                "method post"
+        );
+        runtime.engine.assign(AssignType.STRING, "prevReqBody", "karate.prevRequest.body", false);
+        notContains(get("prevReqBody"), "multipart/mixed");
+    }
+
+    @Test
     void testMultiPartFileNullCharset() {
         background().scenario(
                 "pathMatches('/hello')",


### PR DESCRIPTION
… "multipart/mixed" body

### Description

- Relevant Issues : Prevent deprecated multipart/mixed content-type, see this [thread](https://stackoverflow.com/questions/74899282/karate-multipart-file-array-uses-deprecated-multipart-mixed-content-type)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
