### PR TITLE
chore: use update thymeleaf syntax

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/report/karate-feature.html
+++ b/karate-core/src/main/java/com/intuit/karate/report/karate-feature.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="res/bootstrap.min.js"></script>
     <script type="text/javascript" src="res/karate-report.js"></script>
     <script type="text/javascript" src="res/Resemble.js"></script>
-    <th:block th:insert="karate-posthog.html" th:with="karateEvent: 'report_feature'"></th:block>
+    <th:block th:insert="~{karate-posthog.html}" th:with="karateEvent: 'report_feature'"></th:block>
     <title th:text="results.packageQualifiedName"></title>
   </head>
   <body>
@@ -28,7 +28,7 @@
           };
           var repeat = n => Array.from({length: n}, (v, k) => k);
         </script>
-        <div th:replace="karate-leftnav.html"></div>
+        <div th:replace="~{karate-leftnav.html}"></div>
         <div class="nav-container">
           <div class="nav-item" th:each="scenario: results.scenarioResults" th:classappend="scenario.failed ? 'failed' : 'passed'">
             <a th:href="'#' + scenario.refId"><span th:text="scenario.refId"></span> <span th:text="scenario.name"></span></a>
@@ -71,7 +71,7 @@
                th:unless="sr.hidden"
                th:attr="'data-parent': sr.step.background ? scenario.refId + 'bg' : null"
                th:with="callDepth: 0, parentId: null, isBackground: sr.step.background"
-               th:include="karate-step.html">
+               th:insert="~{karate-step.html}">
           </div>
         </div>
       </div>


### PR DESCRIPTION
Running karate with current thymeleaf versions generates some warnings for `karate-feature.html`:

```
[THYMELEAF][main][karate-feature.html] Deprecated unwrapped fragment expression \"karate-posthog.html\" found in template karate-feature.html, line 15, col 15. Please use the complete syntax of fragment expressions instead (\"~{karate-posthog.html}\")
```

```
[THYMELEAF][main][karate-feature.html] Deprecated attribute {th:include,data-th-include} found in template karate-feature.html, line 74, col 16. Please use {th:insert,data-th-insert} instead, this deprecated attribute will be removed in future versions of Thymeleaf
```

```
[THYMELEAF][main][karate-feature.html] Deprecated unwrapped fragment expression \"karate-leftnav.html\" found in template karate-feature.html, line 31, col 14. Please use the complete syntax of fragment expressions instead (\"~{karate-leftnav.html}\"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf
```

This PR fixes those by using current syntax, similar to https://github.com/karatelabs/karate/pull/2368.

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
