### PR TITLE
Http using RuntimeHook

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Http.java
+++ b/karate-core/src/main/java/com/intuit/karate/Http.java
@@ -75,6 +75,11 @@ public class Http {
         return this;
     }
 
+    public Http hook(RuntimeHook hook) {
+        builder.hook(hook);
+        return this;
+    }
+
     public Response method(String method, Object body) {        
         if (body != null) {
             builder.body(body instanceof Json ? ((Json) body).value() : body);

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
@@ -25,6 +25,7 @@ package com.intuit.karate.http;
 
 import com.intuit.karate.Json;
 import com.intuit.karate.JsonUtils;
+import com.intuit.karate.RuntimeHook;
 import com.intuit.karate.StringUtils;
 import com.intuit.karate.graal.JsArray;
 import com.intuit.karate.graal.JsValue;
@@ -103,7 +104,7 @@ public class HttpRequestBuilder implements ProxyObject {
     private Object body;
     private Set<Cookie> cookies;
     private String retryUntil;
-
+    private RuntimeHook hook;
     public final HttpClient client;
 
     public HttpRequestBuilder(HttpClient client) {
@@ -517,6 +518,15 @@ public class HttpRequestBuilder implements ProxyObject {
         }
         multiPart.part(map);
         return this;
+    }
+
+    public HttpRequestBuilder hook(RuntimeHook hook) {
+        this.hook = hook;
+        return this;
+    }
+
+    public RuntimeHook hook() {
+        return hook;
     }
 
     //==========================================================================

--- a/karate-core/src/test/java/com/intuit/karate/HttpTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/HttpTest.java
@@ -1,0 +1,39 @@
+package com.intuit.karate;
+
+import com.intuit.karate.core.ScenarioRuntime;
+import com.intuit.karate.http.HttpRequest;
+import com.intuit.karate.http.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpTest {
+
+    static class TestRuntimeHook implements RuntimeHook {
+        @Override
+        public void beforeHttpCall(HttpRequest request, ScenarioRuntime sr) {
+            String url = request.getUrl();
+            request.setUrl(url.substring(0, url.length() - 1) + "2");
+        }
+
+        @Override
+        public void afterHttpCall(HttpRequest request, Response response, ScenarioRuntime sr) {
+            response.setBody(response.json().set("username", "Karate").toString());
+        }
+    }
+
+    @Test
+    void testInvokeWithoutHook() {
+        Response response = Http.to("https://jsonplaceholder.typicode.com/users/1").header("Accept", "application/json").get();
+        assertEquals("1", response.json().get("id").toString());
+        assertEquals("Bret", response.json().get("username").toString());
+    }
+
+    @Test
+    void testInvokeWithHook() {
+        Response response = Http.to("https://jsonplaceholder.typicode.com/users/1").header("Accept", "application/xml").hook(new TestRuntimeHook()).get();
+        assertEquals("2", response.json().get("id").toString());
+        assertEquals("Karate", response.json().get("username").toString());
+    }
+
+}


### PR DESCRIPTION
### Description

Allows to set a RuntimeHook on a Http instance when called from Java.

- Relevant Issues : #2381
- Type of change :
  - [x ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
