### PR TITLE
refactor: equals avoids null

### DIFF
--- a/karate-demo/src/main/java/com/intuit/karate/demo/controller/EchoController.java
+++ b/karate-demo/src/main/java/com/intuit/karate/demo/controller/EchoController.java
@@ -77,7 +77,7 @@ public class EchoController {
     
     @PostMapping("/binary")
     public Binary create(@RequestBody Binary bin) {
-        if (!bin.getMessage().equals("hello")) {
+        if (!"hello".equals(bin.getMessage())) {
             throw new RuntimeException("expected message 'hello' but was: " + bin.getMessage());
         }
         if (!Arrays.equals("hello".getBytes(), bin.getData())) {

--- a/karate-demo/src/main/java/com/intuit/karate/demo/controller/HeadersController.java
+++ b/karate-demo/src/main/java/com/intuit/karate/demo/controller/HeadersController.java
@@ -62,7 +62,7 @@ public class HeadersController {
             @RequestParam String url) {
         String temp = tokens.get(token);
         String auth = authorization[0];
-        if (auth.equals("dummy")) {
+        if ("dummy".equals(auth)) {
             auth = authorization[1];
         }
         if (temp.equals(time) && auth.equals(token + time + url)) {

--- a/karate-demo/src/test/java/demo/oauth/Signer.java
+++ b/karate-demo/src/test/java/demo/oauth/Signer.java
@@ -41,7 +41,7 @@ public static void sign(String token, Map<String, String> params) {
         String tokenClientSlat = "";
         for (Map.Entry<String, String> entry : params.entrySet()) {
             String key = entry.getKey();
-            if (key.equals("token_client_salt")) {
+            if ("token_client_salt".equals(key)) {
                 tokenClientSlat = entry.getValue();
             }
             String paramString = key + "=" + entry.getValue();


### PR DESCRIPTION
Happy Hacktoberfest!

This refactor checks that any combination of String literals is on the left side of an equals() comparison to prevent null pointer exceptions.

:beers: Cheers,
Kyle