### PR TITLE
Fix: XML whitespace trims while pretty print

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -72,10 +72,13 @@ public class XmlUtils {
     }
 
     public static String toString(Node node, boolean pretty) {
+        Node nodeToSerialize = node;
+        // In case of pretty string, we clone the node so that we don't modify the original node while trimming whitespaces
         if (pretty) {
-            trimWhiteSpace(node);
+            nodeToSerialize = node.cloneNode(true);
+            trimWhiteSpace(nodeToSerialize);
         }
-        DOMSource domSource = new DOMSource(node);
+        DOMSource domSource = new DOMSource(nodeToSerialize);
         StringWriter writer = new StringWriter();
         StreamResult result = new StreamResult(writer);
         TransformerFactory tf = TransformerFactory.newInstance();

--- a/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
@@ -227,6 +227,23 @@ class XmlUtilsTest {
     }
 
     @Test
+    void testPrettyPrintWithWhiteSpace() {
+        String xml = "<foo><bar>baz</bar><ban><goo>moo   </goo></ban></foo>";
+        Document doc = XmlUtils.toXmlDoc(xml);
+        String temp = XmlUtils.toString(doc, true);
+        String expected
+                = "<foo>\n"
+                + "  <bar>baz</bar>\n"
+                + "  <ban>\n"
+                + "    <goo>moo</goo>\n"
+                + "  </ban>\n"
+                + "</foo>\n";
+
+        expected = expected.replace("\n", System.lineSeparator());
+        assertEquals(temp, expected);
+    }
+
+    @Test
     void testCreatingNewDocumentFromSomeChildNode() {
         String xml = "<root><foo><bar>baz</bar></foo></root>";
         Document doc = XmlUtils.toXmlDoc(xml);

--- a/karate-core/src/test/java/com/intuit/karate/core/xml/xml.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/xml/xml.feature
@@ -505,3 +505,25 @@ Scenario: xml matching involving karate-schema substitutions
 </root>
 """
 * match test2 == schema
+
+Scenario: Xml whitespace trim after print bug fix
+* def setForecastRequestXml =
+    """
+    <myroot>
+        <myelement>T </myelement>
+    </myroot>
+    """
+* match setForecastRequestXml //myelement == 'T '
+* print setForecastRequestXml
+* match setForecastRequestXml //myelement == 'T '
+
+Scenario: Xml whitespace trim after karate.log bug fix
+* def setForecastRequestXml =
+    """
+    <myroot>
+        <myelement> T </myelement>
+    </myroot>
+    """
+* match setForecastRequestXml //myelement == ' T '
+* karate.log(setForecastRequestXml)
+* match setForecastRequestXml //myelement == ' T '

--- a/karate-core/src/test/java/com/intuit/karate/core/xml/xml.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/xml/xml.feature
@@ -516,6 +516,7 @@ Scenario: Xml whitespace trim after print bug fix
 * match setForecastRequestXml //myelement == 'T '
 * print setForecastRequestXml
 * match setForecastRequestXml //myelement == 'T '
+* match setForecastRequestXml //myelement != 'T'
 
 Scenario: Xml whitespace trim after karate.log bug fix
 * def setForecastRequestXml =
@@ -527,3 +528,4 @@ Scenario: Xml whitespace trim after karate.log bug fix
 * match setForecastRequestXml //myelement == ' T '
 * karate.log(setForecastRequestXml)
 * match setForecastRequestXml //myelement == ' T '
+* match setForecastRequestXml //myelement != 'T'


### PR DESCRIPTION

### Description

The above PR resolves the bug which causes the XML element with whitespace in the left or right to be trimmed after passing the variable through karate.log or print.

The idea of the fix is to clone a temporary node while serializing the XML node to string in case of pretty print, as the code trims the whitespace of the element while pretty printing and does that directly on the object itself causing it to change.

Issue: #2385 

Screenshots of failing test cases before the changes:
<img width="987" alt="Screenshot 2023-10-10 at 8 32 49 PM" src="https://github.com/karatelabs/karate/assets/25502696/d705b58c-cdba-42ae-ba48-4a44f53bd321">


Thanks for contributing to this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : https://github.com/karatelabs/karate/issues/2385
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
