### PR TITLE
Fix 2419 - Multipart form fields ignoring numeric data

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -491,6 +491,9 @@ public class ScenarioEngine {
         if (name != null) {
             map.put("name", name);
         }
+        if(value instanceof Integer || value instanceof Float || value instanceof Double) {
+            value = value.toString();
+        }
         if (value instanceof Map) {
             map.putAll((Map) value);
             String toRead = (String) map.get("read");

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -491,7 +491,7 @@ public class ScenarioEngine {
         if (name != null) {
             map.put("name", name);
         }
-        if(value instanceof Integer || value instanceof Float || value instanceof Double) {
+        if(value instanceof Number) {
             value = value.toString();
         }
         if (value instanceof Map) {

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
@@ -391,6 +391,36 @@ class KarateMockHandlerTest {
     }
 
     @Test
+    void testMultiPartFieldWithInteger() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def response = requestParams");
+        run(
+                URL_STEP,
+                "def data = { foo: 'a', bar: 1}",
+                "multipart fields data",
+                "path 'hello'",
+                "method post"
+        );
+        matchVar("response", "{  foo: ['a'], bar: ['1'] } }");
+    }
+
+    @Test
+    void testMultiPartFieldWithFloat() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def response = requestParams");
+        run(
+                URL_STEP,
+                "def data = { foo: 1, bar: 2.0}",
+                "multipart fields data",
+                "path 'hello'",
+                "method post"
+        );
+        matchVar("response", "{ foo: ['1'], bar: ['2.0'] } }");
+    }
+
+    @Test
     void testMultiPartFile() {
         background().scenario(
                 "pathMatches('/hello')",


### PR DESCRIPTION
### Description

This PR resolves the bug that ignores numeric data while testing with multipart form fields.

The fix was to convert any numeric data to string before they are added to the hashmap

- Relevant Issues : [2419](https://github.com/karatelabs/karate/issues/2419)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
