### PR TITLE
Add silent option for gatling karate builder

### DIFF
--- a/karate-gatling/README.md
+++ b/karate-gatling/README.md
@@ -301,6 +301,9 @@ And to run scenarios tagged `foo` AND `bar`
   val delete = scenario("delete").exec(karateFeature("classpath:mock/cats-delete.feature", "@foo", "@bar"))
 ```
 
+#### Silent execution
+It is possible to set a `karateFeature()` to be silent, this allows the request executions to not be counter towards the gatling statistics, this is specially useful if you are planning to execute a warm-up process that could call the possible flows before the performance test starts, making sure all the flows will be compiled on the server before counting statistics like request time.
+
 ### Karate Variables
 On the Scala side, after a `scenario` involving a [`karateFeature()`](#karatefeature) completes, the Karate variables that were part of the feature will be added to the [Gatling session](#gatling-session).
 

--- a/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
+++ b/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
@@ -43,7 +43,7 @@ import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
 class KarateFeatureAction(val name: String, val tags: Seq[String], val protocol: KarateProtocol, val system: ActorSystem,
-                          val statsEngine: StatsEngine, val clock: Clock, val next: Action, val isSilent: Boolean = FALSE) extends ExitableAction {
+                          val statsEngine: StatsEngine, val clock: Clock, val next: Action, val isSilent: Boolean = false) extends ExitableAction {
 
   override def execute(session: Session) = {
 

--- a/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
+++ b/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
@@ -73,6 +73,9 @@ class KarateFeatureAction(val name: String, val tags: Seq[String], val protocol:
       }
 
       override def reportPerfEvent(event: PerfEvent): Unit = {
+        if(isSilent){
+          return
+        }
         val okOrNot = if (event.isFailed) KO else OK
         val message = if (event.getMessage == null) None else Option(event.getMessage)
         statsEngine.logResponse(session.scenario, session.groups, event.getName, event.getStartTime, event.getEndTime, okOrNot, Option(event.getStatusCode.toString), message)

--- a/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
+++ b/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
@@ -43,7 +43,7 @@ import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
 class KarateFeatureAction(val name: String, val tags: Seq[String], val protocol: KarateProtocol, val system: ActorSystem,
-                          val statsEngine: StatsEngine, val clock: Clock, val next: Action) extends ExitableAction {
+                          val statsEngine: StatsEngine, val clock: Clock, val next: Action, val isSilent: Boolean = FALSE) extends ExitableAction {
 
   override def execute(session: Session) = {
 
@@ -125,9 +125,16 @@ class KarateFeatureAction(val name: String, val tags: Seq[String], val protocol:
 
 class KarateFeatureActionBuilder(name: String, tags: Seq[String]) extends ActionBuilder {
 
+  private var isSilent = false
+  
+  def silent(): SilentKarateFeatureActionBuilder = {
+      this.isSilent = true;
+      this;
+  }
+
   override def build(ctx: ScenarioContext, next: Action): Action = {
     val karateComponents = ctx.protocolComponentsRegistry.components(KarateProtocol.KarateProtocolKey)
-    new KarateFeatureAction(name, tags, karateComponents.protocol, karateComponents.system, ctx.coreComponents.statsEngine, ctx.coreComponents.clock, next)
+    new KarateFeatureAction(name, tags, karateComponents.protocol, karateComponents.system, ctx.coreComponents.statsEngine, ctx.coreComponents.clock, next, isSilent)
   }
 
 }

--- a/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
+++ b/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateActions.scala
@@ -127,7 +127,7 @@ class KarateFeatureActionBuilder(name: String, tags: Seq[String]) extends Action
 
   private var isSilent = false
   
-  def silent(): SilentKarateFeatureActionBuilder = {
+  def silent(): KarateFeatureActionBuilder = {
       this.isSilent = true;
       this;
   }

--- a/karate-gatling/src/test/scala/mock/CatsSimulationWithSilentWarmUp.scala
+++ b/karate-gatling/src/test/scala/mock/CatsSimulationWithSilentWarmUp.scala
@@ -1,0 +1,48 @@
+package mock
+
+import com.intuit.karate.Runner
+import com.intuit.karate.gatling.PreDef._
+import io.gatling.core.Predef._
+
+import scala.concurrent.duration._
+
+class CatsSimulation extends Simulation {
+
+  MockUtils.startServer(0)
+
+  val protocol = karateProtocol(
+    "/cats/{id}" -> Nil,
+    "/cats" -> pauseFor("get" -> 15, "post" -> 25)
+  )
+
+  protocol.nameResolver = (req, ctx) => req.getHeader("karate-name")
+  protocol.runner.karateEnv("perf")
+
+  val createWarmup = scenario("create warm-up").exec(karateFeature("classpath:mock/cats-create.feature").silent)
+  val create = scenario("create").exec(karateFeature("classpath:mock/cats-create.feature")).exec(session => {
+    println("*** id in gatling: " + session("id").as[String])
+    println("*** session status in gatling: " + session.status)
+    session
+  })
+
+  val deleteWarmup = scenario("delete warm-up").exec(karateFeature("classpath:mock/cats-delete.feature").silent)
+  val delete = scenario("delete").group("delete cats") {
+    exec(karateFeature("classpath:mock/cats-delete.feature@name=delete"))
+  }
+  
+  val customWarmup = scenario("custom warm-up").exec(karateFeature("classpath:mock/cats-rpc.feature").silent)
+  val custom = scenario("custom").exec(karateFeature("classpath:mock/custom-rpc.feature"))
+
+  setUp(
+    createWarmup.inject(rampUsers(1) during (5 seconds)).AndThen(
+      create.inject(rampUsers(10) during (5 seconds))
+    ),
+    deleteWarmup.inject(rampUsers(1) during (5 seconds)).AndThen(
+      delete.inject(rampUsers(5) during (5 seconds))
+    ),
+    customWarmup.inject(rampUsers(1) during (5 seconds)).AndThen(
+      custom.inject(rampUsers(10) during (5 seconds))
+    )
+  ).protocols(protocol)
+
+}

--- a/karate-gatling/src/test/scala/mock/CatsSimulationWithSilentWarmUp.scala
+++ b/karate-gatling/src/test/scala/mock/CatsSimulationWithSilentWarmUp.scala
@@ -1,8 +1,10 @@
 package mock
 
 import com.intuit.karate.Runner
+import com.intuit.karate.gatling.KarateProtocol
 import com.intuit.karate.gatling.PreDef._
 import io.gatling.core.Predef._
+import io.gatling.core.structure.ScenarioBuilder
 
 import scala.concurrent.duration._
 
@@ -10,7 +12,7 @@ class CatsSimulationWithSilentWarmUp extends Simulation {
 
   MockUtils.startServer(0)
 
-  val protocol = karateProtocol(
+  val protocol: KarateProtocol = karateProtocol(
     "/cats/{id}" -> Nil,
     "/cats" -> pauseFor("get" -> 15, "post" -> 25)
   )
@@ -18,20 +20,20 @@ class CatsSimulationWithSilentWarmUp extends Simulation {
   protocol.nameResolver = (req, ctx) => req.getHeader("karate-name")
   protocol.runner.karateEnv("perf")
 
-  val createWarmup = scenario("create warm-up").exec(karateFeature("classpath:mock/cats-create.feature").silent)
-  val create = scenario("create").exec(karateFeature("classpath:mock/cats-create.feature")).exec(session => {
+  val createWarmup: ScenarioBuilder = scenario("create warm-up").exec(karateFeature("classpath:mock/cats-create.feature").silent())
+  val create: ScenarioBuilder = scenario("create").exec(karateFeature("classpath:mock/cats-create.feature")).exec(session => {
     println("*** id in gatling: " + session("id").as[String])
     println("*** session status in gatling: " + session.status)
     session
   })
 
-  val deleteWarmup = scenario("delete warm-up").exec(karateFeature("classpath:mock/cats-delete.feature").silent)
-  val delete = scenario("delete").group("delete cats") {
+  val deleteWarmup: ScenarioBuilder = scenario("delete warm-up").exec(karateFeature("classpath:mock/cats-delete.feature").silent())
+  val delete: ScenarioBuilder = scenario("delete").group("delete cats") {
     exec(karateFeature("classpath:mock/cats-delete.feature@name=delete"))
   }
   
-  val customWarmup = scenario("custom warm-up").exec(karateFeature("classpath:mock/cats-rpc.feature").silent)
-  val custom = scenario("custom").exec(karateFeature("classpath:mock/custom-rpc.feature"))
+  val customWarmup: ScenarioBuilder = scenario("custom warm-up").exec(karateFeature("classpath:mock/cats-rpc.feature").silent())
+  val custom: ScenarioBuilder = scenario("custom").exec(karateFeature("classpath:mock/custom-rpc.feature"))
 
   setUp(
     createWarmup.inject(rampUsers(1) during (5 seconds)).andThen(

--- a/karate-gatling/src/test/scala/mock/CatsSimulationWithSilentWarmUp.scala
+++ b/karate-gatling/src/test/scala/mock/CatsSimulationWithSilentWarmUp.scala
@@ -6,7 +6,7 @@ import io.gatling.core.Predef._
 
 import scala.concurrent.duration._
 
-class CatsSimulation extends Simulation {
+class CatsSimulationWithSilentWarmUp extends Simulation {
 
   MockUtils.startServer(0)
 
@@ -34,13 +34,13 @@ class CatsSimulation extends Simulation {
   val custom = scenario("custom").exec(karateFeature("classpath:mock/custom-rpc.feature"))
 
   setUp(
-    createWarmup.inject(rampUsers(1) during (5 seconds)).AndThen(
+    createWarmup.inject(rampUsers(1) during (5 seconds)).andThen(
       create.inject(rampUsers(10) during (5 seconds))
     ),
-    deleteWarmup.inject(rampUsers(1) during (5 seconds)).AndThen(
+    deleteWarmup.inject(rampUsers(1) during (5 seconds)).andThen(
       delete.inject(rampUsers(5) during (5 seconds))
     ),
-    customWarmup.inject(rampUsers(1) during (5 seconds)).AndThen(
+    customWarmup.inject(rampUsers(1) during (5 seconds)).andThen(
       custom.inject(rampUsers(10) during (5 seconds))
     )
   ).protocols(protocol)


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

In my scenario, I would like to do a warm-up phase before my real performance test. I'd like to be able to reach all tested flows in order for the server to compile the code beforehand and not affect my response time (useful for .NET and JAVA servers).
For that, I implemented a feature like the .silent on the Gatling HTTP and HTTPProtocol.

I've added a unit test with the warm-up flow for one existing simulation 

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X] Addition or Improvement of tests
  - [X] Addition or Improvement of documentation
