### PR TITLE
Bump linecorp version

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.linecorp.armeria</groupId>
             <artifactId>armeria</artifactId>
-            <version>1.25.2</version>
+            <version>1.26.2</version>
         </dependency>              
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Bumps linecorp version to latest version so it also updates netty http codec to 4.1.100 final to solve a snyk issue

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : https://github.com/karatelabs/karate/issues/2401
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
