### PR TITLE
Remove trimWhiteSpace call from XmlUtils.toString #2451

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -72,13 +72,7 @@ public class XmlUtils {
     }
 
     public static String toString(Node node, boolean pretty) {
-        Node nodeToSerialize = node;
-        // In case of pretty string, we clone the node so that we don't modify the original node while trimming whitespaces
-        if (pretty) {
-            nodeToSerialize = node.cloneNode(true);
-            trimWhiteSpace(nodeToSerialize);
-        }
-        DOMSource domSource = new DOMSource(nodeToSerialize);
+        DOMSource domSource = new DOMSource(node);
         StringWriter writer = new StringWriter();
         StreamResult result = new StreamResult(writer);
         TransformerFactory tf = TransformerFactory.newInstance();

--- a/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
@@ -228,18 +228,27 @@ class XmlUtilsTest {
 
     @Test
     void testPrettyPrintWithWhiteSpace() {
-        String xml = "<foo><bar>baz</bar><ban><goo>moo   </goo></ban></foo>";
+        String xml = "<foo><bar>baz</bar><ban><goo> moo   </goo></ban></foo>";
         Document doc = XmlUtils.toXmlDoc(xml);
         String temp = XmlUtils.toString(doc, true);
         String expected
                 = "<foo>\n"
                 + "  <bar>baz</bar>\n"
                 + "  <ban>\n"
-                + "    <goo>moo</goo>\n"
+                + "    <goo> moo   </goo>\n"
                 + "  </ban>\n"
                 + "</foo>\n";
 
         expected = expected.replace("\n", System.lineSeparator());
+        assertEquals(temp, expected);
+    }
+
+    @Test
+    void testNonPrettyPrintWithWhiteSpace() {
+        String xml = "<foo><bar>baz</bar><ban><goo> moo   </goo></ban></foo>";
+        Document doc = XmlUtils.toXmlDoc(xml);
+        String temp = XmlUtils.toString(doc, false);
+        String expected = "<foo><bar>baz</bar><ban><goo> moo   </goo></ban></foo>";
         assertEquals(temp, expected);
     }
 


### PR DESCRIPTION
### Removes trimWhiteSpace call from XmlUtils.toString(node,pretty) so that prettyprinting affects the space between nodes, but not space within node values. Added/amended tests to demonstrate intended behaviour.

- Relevant Issues : #2451 
- Type of change :
  - [ ] New feature
  - [x ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
