### PR TITLE
Update JsEngineTest.java

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/graal/JsEngineTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/graal/JsEngineTest.java
@@ -5,6 +5,7 @@ import com.intuit.karate.core.MockUtils;
 import com.intuit.karate.http.Request;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -256,7 +257,7 @@ class JsEngineTest {
     
     @Test
     void testObjectsWithinFunction() {
-        Map<String, Object> map = new HashMap();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("a", 1);
         map.put("b", 2);
         je.put("o", map);


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[com.intuit.karate.graal.JsEngineTest#testObjectsWithinFunction](https://github.com/karatelabs/karate/blob/628428c5f94772a40ae6f330f806388e6dfb0118/karate-core/src/test/java/com/intuit/karate/graal/JsEngineTest.java#L258)

Test Overview:
_________________________________________________________________________________________________________
In the above test, the map has been initialized as a HashMap which is non-deterministic in nature. It doesn't return the elements in the order in which they are stored.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
[ERROR] com.intuit.karate.graal.JsEngineTest.testObjectsWithinFunction  Time elapsed: 0.016 s  <<< ERROR!
java.lang.RuntimeException: 
match failed: EQUALS
  $ | not equal | array match failed at index 0 (LIST:LIST)
  [["b",2],["a",1]]
  [["a",1],["b",2]]

    $[0] | not equal | array match failed at index 0 (LIST:LIST)
    ["b",2]
    ["a",1]

      $[0][0] | not equal (STRING:STRING)
      'b'
      'a'

```


You can reproduce the issue by running the following commands:

```
mvn install -pl  karate-core  -am -DskipTests
mvn test -pl karate-core  -Dtest=com.intuit.karate.graal.JsEngineTest#testObjectsWithinFunction 
mvn -pl karate-core edu.illinois:index-maven-plugin:2.1.1:nondex -Dtest=com.intuit.karate.graal.JsEngineTest#testObjectsWithinFunction
```

Fix:
_________________________________________________________________________________________________________
To fix the issue I have changed the HashMap with LinkedHashMap which is deterministic in nature.

https://github.com/njain2208/karate/blob/ed230bd083139bb1c24edcfbe74ebbb4208524ed/karate-core/src/test/java/com/intuit/karate/graal/JsEngineTest.java#L259-L267