### PR TITLE
fix system properties issue on runner #2474

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -163,9 +163,7 @@ public class Runner {
             if (systemProperties == null) {
                 systemProperties = new HashMap(System.getProperties());
             } else {
-                Map temp = new HashMap(System.getProperties());
-                temp.putAll(systemProperties); // make sure user-specified takes precedence
-                systemProperties = temp;
+                systemProperties.putAll(new HashMap(System.getProperties()));
             }
             // env
             String tempOptions = StringUtils.trimToNull(systemProperties.get(Constants.KARATE_OPTIONS));

--- a/karate-core/src/test/java/com/intuit/karate/SystemPropertiesTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/SystemPropertiesTest.java
@@ -1,0 +1,43 @@
+package com.intuit.karate;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import com.intuit.karate.Runner.Builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SystemPropertiesTest {
+
+  private static final String TEST_PROP = "testProperty";
+
+  @AfterEach
+  void clearTestProperty() {
+    System.clearProperty(TEST_PROP);
+  }
+
+  @Test
+  void testSystemPropertiesSetOnRunner() {
+    Builder<?> builder = Runner.builder().systemProperty(TEST_PROP, "setOnRunner");
+    builder.resolveAll();
+    String propertyValue = builder.systemProperties.get(TEST_PROP);
+    assertEquals(propertyValue, "setOnRunner");
+  }
+
+  @Test
+  void testSystemPropertiesSetOnJVM() {
+    System.setProperty(TEST_PROP, "setOnJVM"); // -DtestProperty=setOnJVM
+    Builder<?> builder = Runner.builder();
+    builder.resolveAll();
+    String propertyValue = builder.systemProperties.get(TEST_PROP);
+    assertEquals(propertyValue, "setOnJVM");
+  }
+
+  @Test
+  void testPrecedenceOfSystemPropertiesSetOnRunnerAndJVM() {
+    System.setProperty(TEST_PROP, "setOnJVM"); // -DtestProperty=setOnJVM
+    Builder<?> builder = Runner.builder().systemProperty(TEST_PROP, "setOnRunner");
+    builder.resolveAll();
+    String propertyValue = builder.systemProperties.get(TEST_PROP);
+    assertEquals(propertyValue, "setOnJVM");
+  }
+}


### PR DESCRIPTION
### Description

Fixes the precedence issue on system properties when using the Runner.
System properties set on the JVM (e.g. -Dproperty=value) will override values with the same property name set using the `systemProperty` API on the Java Runner.

- Relevant Issues : #2474
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
