### PR TITLE
fix thread count issue when using karate.options #2444

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -94,7 +94,7 @@ public class Main implements Callable<Void> {
     List<String> tags;
 
     @Option(names = {"-T", "--threads"}, description = "number of threads when running tests")
-    int threads = 1;
+    Integer threads;
 
     @Option(names = {"-o", "--output"}, description = "directory where logs and reports are output (default 'target')")
     String output = FileUtils.getBuildDir();
@@ -328,6 +328,9 @@ public class Main implements Callable<Void> {
                 System.out.println(message);
             }
             return null;
+        }
+        if (threads == null) {
+            threads = 1;
         }
         if (paths != null) {
             Results results = Runner

--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -176,7 +176,7 @@ public class Runner {
                 if (ko.paths != null) {
                     paths = ko.paths;
                 }
-                if (ko.threads != threadCount) { // 1 by default
+                if (ko.threads != null) {
                     threadCount = ko.threads;
                 }
                 dryRun = ko.dryRun || dryRun;

--- a/karate-core/src/test/java/com/intuit/karate/ThreadCountTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/ThreadCountTest.java
@@ -1,0 +1,48 @@
+package com.intuit.karate;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static com.intuit.karate.Constants.KARATE_OPTIONS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ThreadCountTest {
+
+  private static final int THREAD_COUNT = 20;
+
+  @AfterEach
+  void clearKarateOptionsProperty() {
+    System.clearProperty(KARATE_OPTIONS);
+  }
+
+  @Test
+  void testThreadCountFromRunner() {
+    Runner.Builder<?> builder = Runner.builder();
+    builder.path("does-not-exist").parallel(THREAD_COUNT);
+    assertEquals(builder.threadCount, THREAD_COUNT);
+  }
+
+  @Test
+  void testThreadCountFromKarateOptionsShortName() {
+    System.setProperty(KARATE_OPTIONS, "-T" + THREAD_COUNT);
+    Runner.Builder<?> builder = Runner.builder();
+    builder.path("does-not-exist").parallel(1);
+    assertEquals(builder.threadCount, THREAD_COUNT);
+  }
+
+  @Test
+  void testThreadCountFromKarateOptionsLongName() {
+    System.setProperty(KARATE_OPTIONS, "--threads=" + THREAD_COUNT);
+    Runner.Builder<?> builder = Runner.builder();
+    builder.path("does-not-exist").parallel(1);
+    assertEquals(builder.threadCount, THREAD_COUNT);
+  }
+
+  @Test
+  void testThreadCountFromRunnerAndKarateOptionsWithoutThreadOption() {
+    System.setProperty(KARATE_OPTIONS, "--tags=@does-not-exist");
+    Runner.Builder<?> builder = Runner.builder();
+    builder.path("does-not-exist").parallel(THREAD_COUNT);
+    assertEquals(builder.threadCount, THREAD_COUNT);
+  }
+}


### PR DESCRIPTION
### Description

Fixes the case where using karate.options without the -T or --threads option causes the Runner to use the default of 1 thread.

- Relevant Issues : #2444 
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
