### PR TITLE
Enable Calling Scenario By Tag

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioRuntime.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioRuntime.java
@@ -332,11 +332,10 @@ public class ScenarioRuntime implements Runnable {
         }
         String callTag = fr.featureCall.callTag;
         if (callTag != null) {
-            // only if this is a legit "call" or a gatling "call by tag"
-            if (tags.contains(callTag) && (!fr.caller.isNone() || fr.perfHook != null)) {
+            if (tags.contains(callTag)) {
                 logger.info("{} - call by tag at line {}: {}", fr, scenario.getLine(), callTag);
                 return true;
-            } else if (!fr.caller.isNone() || fr.perfHook != null) {
+            } else {
                 logger.trace("skipping scenario at line: {} with call by tag effective: {}", scenario.getLine(), callTag);
                 return false;
             }

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioRuntime.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioRuntime.java
@@ -331,14 +331,15 @@ public class ScenarioRuntime implements Runnable {
             return false;
         }
         String callTag = fr.featureCall.callTag;
-        if (callTag != null && (!fr.caller.isNone() || fr.perfHook != null)) {
+        if (callTag != null) {
             // only if this is a legit "call" or a gatling "call by tag"
-            if (tags.contains(callTag)) {
+            if (tags.contains(callTag) && (!fr.caller.isNone() || fr.perfHook != null)) {
                 logger.info("{} - call by tag at line {}: {}", fr, scenario.getLine(), callTag);
                 return true;
+            } else if (!fr.caller.isNone() || fr.perfHook != null) {
+                logger.trace("skipping scenario at line: {} with call by tag effective: {}", scenario.getLine(), callTag);
+                return false;
             }
-            logger.trace("skipping scenario at line: {} with call by tag effective: {}", scenario.getLine(), callTag);
-            return false;
         }
         if (fr.caller.isNone()) {
             if (tags.evaluate(fr.suite.tagSelector, fr.suite.env)) {

--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
@@ -411,6 +411,6 @@ class FeatureRuntimeTest {
         featureRuntime.run();
 
         FeatureResult result = featureRuntime.result;
-        matchContains(result.getVariables(), "{ result: 'Two' }");
+        matchContains(result.getVariables(), "{ result2: 'Two' }");
     }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
@@ -1,9 +1,6 @@
 package com.intuit.karate.core;
 
-import com.intuit.karate.Match;
-import com.intuit.karate.Results;
-import com.intuit.karate.Runner;
-import com.intuit.karate.TestUtils;
+import com.intuit.karate.*;
 import com.intuit.karate.report.Report;
 import com.intuit.karate.report.SuiteReports;
 import org.junit.jupiter.api.BeforeEach;
@@ -406,4 +403,14 @@ class FeatureRuntimeTest {
         run("ntlm-authentication.feature");
     }
 
+    @Test
+    void testSingleScenario() {
+        Feature feature = Feature.read("classpath:com/intuit/karate/core/single-scenario.feature");
+        FeatureCall featureCall = new FeatureCall(feature, "@Scenario2", -1, null);
+        FeatureRuntime featureRuntime = FeatureRuntime.of(new Suite(), featureCall, null);
+        featureRuntime.run();
+
+        FeatureResult result = featureRuntime.result;
+        matchContains(result.getVariables(), "{ result: 'Two' }");
+    }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/single-scenario.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/single-scenario.feature
@@ -1,0 +1,13 @@
+Feature: A feature file with multiple scenarios
+
+  @Scenario1
+  Scenario: Set to "One"
+    * def result = 'One'
+
+  @Scenario2
+  Scenario: Set to "Two"
+    * def result = 'Two'
+
+  @Scenario3
+  Scenario: Set to "Three"
+    * def result = 'Three'

--- a/karate-core/src/test/java/com/intuit/karate/core/single-scenario.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/single-scenario.feature
@@ -1,4 +1,4 @@
-Feature: A feature file with multiple scenarios
+Feature: sample feature with distinct signature for each scenario
 
   @Scenario1
   Scenario: Set a Variable to "One"

--- a/karate-core/src/test/java/com/intuit/karate/core/single-scenario.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/single-scenario.feature
@@ -1,13 +1,13 @@
 Feature: A feature file with multiple scenarios
 
   @Scenario1
-  Scenario: Set to "One"
-    * def result = 'One'
+  Scenario: Set a Variable to "One"
+    * def result1 = 'One'
 
   @Scenario2
-  Scenario: Set to "Two"
-    * def result = 'Two'
+  Scenario: Set a Variable to "Two"
+    * def result2 = 'Two'
 
   @Scenario3
-  Scenario: Set to "Three"
-    * def result = 'Three'
+  Scenario: Set a Variable to "Three"
+    * def result3 = 'Three'


### PR DESCRIPTION
### Description

Removal of safeguard that blocks call-by-tag when not done through hooks or another scenario; the safeguard creates unexpected behavior when users attempt to manually call a scenario by tag (as demonstrated by #2501). This pull request comes with a unit test that draws heavily on that example and should prevent future regression.

- Relevant Issues : #2501 
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
