### PR TITLE
test: add tests in DriverOptionsTest.java

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/driver/DriverOptionsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/driver/DriverOptionsTest.java
@@ -36,4 +36,59 @@ class DriverOptionsTest {
         options.retry(() -> 1, x -> x < 5, "not 5", false);
     }
 
+    @Test
+    void testSelectorWithLocatorThatStartWithLeftParentheses() {
+
+        String locator = "(test string)";
+        String contextNode = "test string";
+
+        String result = DriverOptions.selector(locator, contextNode);
+
+        assertEquals("(test string)", result);
+    }
+
+    @Test
+    void testSelectorWithLoctorThatsStartsWithOtherParentheses() {
+
+        String locator = "{}";
+        String contextNode = "test string";
+
+        String result = DriverOptions.selector(locator, contextNode);
+
+        assertFalse(result.contains(locator));
+    }
+
+    @Test
+    void testSelectorWithForwardSlash() {
+
+        String locator = "/tester";
+        String contextNode = "document";
+
+        String result = DriverOptions.selector(locator, contextNode);
+
+        assertTrue(result.startsWith("document.evaluate"));
+    }
+
+    @Test
+    void testSelectorWithContextNodeEqualToDocument() {
+
+        String locator = "/(tester";
+        String contextNode = "document";
+
+        String result = DriverOptions.selector(locator, contextNode);
+
+        assertTrue(result.startsWith("document.evaluate"));
+    }
+
+    @Test
+    void testSelectorWithContextNodeNotEqualToDocument() {
+
+        String locator = "/(tester";
+        String contextNode = "notdocument";
+
+        String result = DriverOptions.selector(locator, contextNode);
+
+        assertTrue(result.startsWith("document.evaluate"));
+    }
+
 }


### PR DESCRIPTION
- Add tests for selector(string, string) in DriverOptionsTest.java that increase coverage of method.

Closes #3

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : These tests are fairly too simple and are only meant to increase the coverage only after discovering that the static method had a zero coverage according to jacoco. Now the coverage lies at 83% with the addition of these tests. The pull request is created from my forked repo of karate
- Relevant PRs : - 
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
