### PR TITLE
reamining features fix #2432

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Suite.java
+++ b/karate-core/src/main/java/com/intuit/karate/Suite.java
@@ -224,6 +224,7 @@ public class Suite implements Runnable {
             }
             hooks.forEach(h -> h.beforeSuite(this));
             int index = 0;
+            List<FeatureRuntime> featureRuntimes = new ArrayList<>(featuresFound);
             for (FeatureCall feature : features) {
                 final int featureNum = ++index;
                 FeatureRuntime fr = FeatureRuntime.of(this, feature);
@@ -233,11 +234,12 @@ public class Suite implements Runnable {
                     onFeatureDone(fr.result, featureNum);
                     future.complete(Boolean.TRUE);
                 });
-                pendingTasks.submit(fr);
+                featureRuntimes.add(fr);
             }
             if (featuresFound > 1) {
                 logger.debug("waiting for {} features to complete", featuresFound);
             }
+            featureRuntimes.forEach(pendingTasks::submit);
             CompletableFuture[] futuresArray = futures.toArray(new CompletableFuture[futures.size()]);
             if (timeoutMinutes > 0) {
                 CompletableFuture.allOf(futuresArray).get(timeoutMinutes, TimeUnit.MINUTES);

--- a/karate-core/src/test/java/com/intuit/karate/core/features/RemainingFeaturesTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/features/RemainingFeaturesTest.java
@@ -1,0 +1,44 @@
+package com.intuit.karate.core.features;
+
+import com.intuit.karate.Results;
+import com.intuit.karate.Runner;
+import com.intuit.karate.Suite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RemainingFeaturesTest {
+
+  private static Suite suite;
+
+  @Test
+  void testRemainingFeaturesSingleThread() {
+    verifyRemainingFeaturesWithThreads(1);
+  }
+
+  @Test
+  void testRemainingFeaturesParallel() {
+    verifyRemainingFeaturesWithThreads(2);
+  }
+
+  /**
+   * Hooks into the current suite to return the remaining features within the test
+   * @return Remaining features count
+   */
+  public static long remainingFeatures() {
+    return suite.getFeaturesRemaining();
+  }
+
+  private void verifyRemainingFeaturesWithThreads(int threads) {
+    Runner.Builder<?> builder = Runner.builder()
+        .path("classpath:com/intuit/karate/core/features")
+        .configDir("classpath:com/intuit/karate/core/features")
+        .threads(threads);
+    builder.resolveAll();
+    suite = new Suite(builder);
+    suite.run();
+    Results results = suite.buildResults();
+    assertEquals(0, results.getFailCount(), results.getErrorMessages());
+  }
+
+}

--- a/karate-core/src/test/java/com/intuit/karate/core/features/feature1.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/features/feature1.feature
@@ -1,0 +1,7 @@
+Feature:
+
+  Scenario: feature test 1
+    * def numOfFeaturesLeft = remainingFeatures()
+    * print 'Features left (including this one):', numOfFeaturesLeft
+    # this is the first feature that runs, so there should be more than 1 feature running
+    * assert numOfFeaturesLeft > 1

--- a/karate-core/src/test/java/com/intuit/karate/core/features/feature2.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/features/feature2.feature
@@ -1,0 +1,7 @@
+Feature:
+
+  Scenario: feature test 2
+    * def numOfFeaturesLeft = remainingFeatures()
+    * print 'Features left (including this one):', numOfFeaturesLeft
+    # there should always be at least 1 feature left, even if it's the current feature running
+    * assert numOfFeaturesLeft >= 1

--- a/karate-core/src/test/java/com/intuit/karate/core/features/karate-config.js
+++ b/karate-core/src/test/java/com/intuit/karate/core/features/karate-config.js
@@ -1,0 +1,8 @@
+function karateConfig() {
+  const config = {}
+
+  const RemainingFeaturesTest = Java.type('com.intuit.karate.core.features.RemainingFeaturesTest')
+  config.remainingFeatures = RemainingFeaturesTest.remainingFeatures
+
+  return config
+}


### PR DESCRIPTION
### Description

This fixes the issue where the remaining features count shows up as 0 whenever the user runs with a single thread. Instead of submitting feature calls as they are created, they will now be stored locally and submitted after creation.

I also had to get a little creative on the tests for this by exposing a static java method to the karate execution scope in order to retrieve the remaining features from the active suite within running scenarios.

- Relevant Issues : #2432
- Relevant PRs : N/A
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
