### PR TITLE
2384: Fix edge case bug for @setup in dry run mode

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Step.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Step.java
@@ -228,7 +228,7 @@ public class Step {
     }
 
     public boolean isSetup() {
-        return scenario.isSetup();
+        return scenario !=null && scenario.isSetup();
     }
 
     @Override

--- a/karate-junit5/src/test/java/karate/setup-with-dryrun.feature
+++ b/karate-junit5/src/test/java/karate/setup-with-dryrun.feature
@@ -1,5 +1,8 @@
 Feature: names
 
+Background:
+    * print 'background'
+
 @setup
 Scenario: first hello world
     * def names = [{"name": "dynamic_1"}, {"name": "dynamic_2"}]


### PR DESCRIPTION
There are steps with no parent scenarios. Ex: background steps.
 - Added null check to handle this scenario.
 - Added a background step to dry run feature test

### Before Fix
[
<img width="1512" alt="Before Fix" src="https://github.com/karatelabs/karate/assets/5775870/0f79e8f1-ede4-4123-a68f-a5a9dd6dc052">
](url)


### After Fix
<img width="1475" alt="After Fix" src="https://github.com/karatelabs/karate/assets/5775870/c4863464-48d6-4fc2-a112-8d2b859c1d9a">



### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : ([compulsory](https://github.com/karatelabs/karate/issues/2384))
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
