### PR TITLE
added fluent api

### DIFF
--- a/karate-gatling/src/main/java/com/intuit/karate/gatling/javaapi/KarateProtocolBuilder.java
+++ b/karate-gatling/src/main/java/com/intuit/karate/gatling/javaapi/KarateProtocolBuilder.java
@@ -46,9 +46,14 @@ public class KarateProtocolBuilder implements ProtocolBuilder {
 
     private final Map<String, Seq<MethodPause>> uriPatterns;
 
-    // Takes a JAVA Map (easier for testing) containaing SCALA MethodPauses (easier to read, save an extra Java MethodPause class and another conversion)
+    // Takes a JAVA Map (easier for testing) containaing SCALA MethodPauses (easier to read, saves an extra Java MethodPause class and another conversion)
     public KarateProtocolBuilder(java.util.Map<String, Seq<MethodPause>> uriPatterns) {
         this.uriPatterns = Converters.toScalaMap(uriPatterns);
+    }
+
+    public KarateProtocolBuilder nameResolver(BiFunction<HttpRequest, ScenarioRuntime, String> nameResolver) {
+        this.nameResolver = nameResolver;
+        return this;
     }
 
     @Override


### PR DESCRIPTION
### Description

Added fluent api to set name resolver (See https://github.com/karatelabs/karate/issues/2168#issuecomment-1963772461)

```
KarateProtocol protocol = 
      karateProtocol(uri("/bla/bla").pauseFor("get", 1000))
            .nameResolver((req, ctx) -> req.getHeader("karate-name"))
            protocol();
```

should now work.

- Relevant Issues : (2168)
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
