### PR TITLE
feat: add Karate runner argument to ignore JUnit 5 no scenarios assertion

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -34,10 +34,11 @@ import com.intuit.karate.driver.DriverRunner;
 import com.intuit.karate.http.HttpClientFactory;
 import com.intuit.karate.report.SuiteReports;
 import com.intuit.karate.resource.ResourceUtils;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -112,6 +113,7 @@ public class Runner {
         boolean outputCucumberJson;
         boolean dryRun;
         boolean debugMode;
+        boolean ignoreJunitNoScenariosAssertion;
         Map<String, String> systemProperties;
         Map<String, Object> callSingleCache;
         Map<String, ScenarioCall.Result> callOnceCache;
@@ -145,6 +147,7 @@ public class Runner {
             b.outputCucumberJson = outputCucumberJson;
             b.dryRun = dryRun;
             b.debugMode = debugMode;
+            b.ignoreJunitNoScenariosAssertion = ignoreJunitNoScenariosAssertion;
             b.systemProperties = systemProperties;
             b.callSingleCache = callSingleCache;
             b.callOnceCache = callOnceCache;
@@ -436,7 +439,10 @@ public class Runner {
             debugMode = value;
             return (T) this;
         }
-
+        public T ignoreJunitNoScenariosAssertion(boolean value) {
+            ignoreJunitNoScenariosAssertion = value;
+            return (T) this;
+        }
         public T callSingleCache(Map<String, Object> value) {
             callSingleCache = value;
             return (T) this;

--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -113,7 +113,7 @@ public class Runner {
         boolean outputCucumberJson;
         boolean dryRun;
         boolean debugMode;
-        boolean ignoreJunitNoScenariosAssertion;
+        boolean failWhenNoScenariosFound;
         Map<String, String> systemProperties;
         Map<String, Object> callSingleCache;
         Map<String, ScenarioCall.Result> callOnceCache;
@@ -147,7 +147,7 @@ public class Runner {
             b.outputCucumberJson = outputCucumberJson;
             b.dryRun = dryRun;
             b.debugMode = debugMode;
-            b.ignoreJunitNoScenariosAssertion = ignoreJunitNoScenariosAssertion;
+            b.failWhenNoScenariosFound = failWhenNoScenariosFound;
             b.systemProperties = systemProperties;
             b.callSingleCache = callSingleCache;
             b.callOnceCache = callOnceCache;
@@ -439,10 +439,12 @@ public class Runner {
             debugMode = value;
             return (T) this;
         }
-        public T ignoreJunitNoScenariosAssertion(boolean value) {
-            ignoreJunitNoScenariosAssertion = value;
+        
+        public T failWhenNoScenariosFound(boolean value) {
+            failWhenNoScenariosFound = value;
             return (T) this;
         }
+
         public T callSingleCache(Map<String, Object> value) {
             callSingleCache = value;
             return (T) this;

--- a/karate-core/src/main/java/com/intuit/karate/Suite.java
+++ b/karate-core/src/main/java/com/intuit/karate/Suite.java
@@ -28,8 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intuit.karate.core.FeatureCall;
 import com.intuit.karate.core.FeatureResult;
 import com.intuit.karate.core.FeatureRuntime;
-import com.intuit.karate.driver.DriverRunner;
-import com.intuit.karate.report.ReportUtils;
 import com.intuit.karate.core.Scenario;
 import com.intuit.karate.core.ScenarioCall;
 import com.intuit.karate.core.ScenarioResult;
@@ -37,27 +35,23 @@ import com.intuit.karate.core.ScenarioRuntime;
 import com.intuit.karate.core.Step;
 import com.intuit.karate.core.SyncExecutorService;
 import com.intuit.karate.core.Tags;
+import com.intuit.karate.driver.DriverRunner;
 import com.intuit.karate.http.HttpClientFactory;
+import com.intuit.karate.report.ReportUtils;
 import com.intuit.karate.report.SuiteReports;
 import com.intuit.karate.resource.Resource;
 import com.intuit.karate.resource.ResourceUtils;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.slf4j.LoggerFactory;
 
 import static java.util.function.Predicate.not;
 
@@ -78,6 +72,7 @@ public class Suite implements Runnable {
     public final String tagSelector;
     public final boolean dryRun;
     public final boolean debugMode;
+    public final boolean ignoreJunitNoScenariosAssertion;
     public final File workingDir;
     public final String buildDir;
     public final String reportDir;
@@ -135,6 +130,7 @@ public class Suite implements Runnable {
         if (rb.forTempUse) {
             dryRun = false;
             debugMode = false;
+            ignoreJunitNoScenariosAssertion = false;
             backupReportDir = false;
             outputHtmlReport = false;
             outputCucumberJson = false;
@@ -179,6 +175,7 @@ public class Suite implements Runnable {
             outputJunitXml = rb.outputJunitXml;
             dryRun = rb.dryRun;
             debugMode = rb.debugMode;
+            ignoreJunitNoScenariosAssertion = rb.ignoreJunitNoScenariosAssertion;
             classLoader = rb.classLoader;
             clientFactory = rb.clientFactory;
             env = rb.env;

--- a/karate-core/src/main/java/com/intuit/karate/Suite.java
+++ b/karate-core/src/main/java/com/intuit/karate/Suite.java
@@ -72,7 +72,7 @@ public class Suite implements Runnable {
     public final String tagSelector;
     public final boolean dryRun;
     public final boolean debugMode;
-    public final boolean ignoreJunitNoScenariosAssertion;
+    public final boolean failWhenNoScenariosFound;
     public final File workingDir;
     public final String buildDir;
     public final String reportDir;
@@ -130,7 +130,7 @@ public class Suite implements Runnable {
         if (rb.forTempUse) {
             dryRun = false;
             debugMode = false;
-            ignoreJunitNoScenariosAssertion = false;
+            failWhenNoScenariosFound = false;
             backupReportDir = false;
             outputHtmlReport = false;
             outputCucumberJson = false;
@@ -175,7 +175,7 @@ public class Suite implements Runnable {
             outputJunitXml = rb.outputJunitXml;
             dryRun = rb.dryRun;
             debugMode = rb.debugMode;
-            ignoreJunitNoScenariosAssertion = rb.ignoreJunitNoScenariosAssertion;
+            failWhenNoScenariosFound = rb.failWhenNoScenariosFound;
             classLoader = rb.classLoader;
             clientFactory = rb.clientFactory;
             env = rb.env;

--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
@@ -67,7 +67,7 @@ public class Karate extends Runner.Builder<Karate> implements Iterable<DynamicNo
             DynamicNode node = DynamicContainer.dynamicContainer(testName, featureNode);
             list.add(node);
         }
-        if (!suite.ignoreJunitNoScenariosAssertion && list.isEmpty()) {
+        if (suite.failWhenNoScenariosFound && list.isEmpty()) {
             Assertions.fail("no features or scenarios found: " + this);
         }
         return list.iterator();

--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
@@ -25,7 +25,6 @@ package com.intuit.karate.junit5;
 
 import com.intuit.karate.Runner;
 import com.intuit.karate.Suite;
-import com.intuit.karate.core.Feature;
 import com.intuit.karate.core.FeatureCall;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicContainer;
@@ -68,7 +67,7 @@ public class Karate extends Runner.Builder<Karate> implements Iterable<DynamicNo
             DynamicNode node = DynamicContainer.dynamicContainer(testName, featureNode);
             list.add(node);
         }
-        if (list.isEmpty()) {
+        if (!suite.ignoreJunitNoScenariosAssertion && list.isEmpty()) {
             Assertions.fail("no features or scenarios found: " + this);
         }
         return list.iterator();

--- a/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
+++ b/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
@@ -5,18 +5,18 @@ import com.intuit.karate.junit5.Karate;
 class NoFeatureNoScenarioTest {
 
     @Karate.Test
-    Karate testValidTagWithIgnoreJunitNoScenarioAssertion() {
+    Karate testHasScenariosWithFailWhenNoScenariosFound() {
         return Karate.run("noFeatureNoScenario")
                      .tags("@smoke")
-                     .ignoreJunitNoScenariosAssertion(true)
-                     .relativeTo(getClass());
-    }
-    @Karate.Test
-    Karate testInvalidTagWithIgnoreJunitNoScenarioAssertion() {
-        return Karate.run("noFeatureNoScenario")
-                     .tags("@tagnotexist")
-                     .ignoreJunitNoScenariosAssertion(true)
+                     .failWhenNoScenariosFound(true)
                      .relativeTo(getClass());
     }
 
+    @Karate.Test
+    Karate testNoScenarios() {
+        return Karate.run("noFeatureNoScenario")
+                     .tags("@tagnotexist")
+                     .failWhenNoScenariosFound(false)
+                     .relativeTo(getClass());
+    }
 }

--- a/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
+++ b/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
@@ -1,0 +1,22 @@
+package karate;
+
+import com.intuit.karate.junit5.Karate;
+
+class NoFeatureNoScenarioTest {
+
+    @Karate.Test
+    Karate testValidTagWithIgnoreJunitNoScenarioAssertion() {
+        return Karate.run("noFeatureNoScenario")
+                     .tags("@smoke")
+                     .ignoreJunitNoScenariosAssertion(true)
+                     .relativeTo(getClass());
+    }
+    @Karate.Test
+    Karate testInvalidTagWithIgnoreJunitNoScenarioAssertion() {
+        return Karate.run("noFeatureNoScenario")
+                     .tags("@tagnotexist")
+                     .ignoreJunitNoScenariosAssertion(true)
+                     .relativeTo(getClass());
+    }
+
+}

--- a/karate-junit5/src/test/java/karate/noFeatureNoScenario.feature
+++ b/karate-junit5/src/test/java/karate/noFeatureNoScenario.feature
@@ -1,0 +1,5 @@
+Feature: ignoreJunitNoScenariosAssertion argument for Karate runner
+
+  @smoke
+  Scenario: smoke
+    * print 'smoke'


### PR DESCRIPTION
### Description

add Karate runner argument ignore no scenarios assertion

If JUnit 5 is used to run a Karate feature file, but no scenarios are found that match the run criteria, this error is thrown:

    no features or scenarios found: [classpath:karate/features/helloworld/]

For example, if Karate is run with these arguments and this feature file, the error will be thrown.

-Dkarate.options="--tags @smoke"

Feature: Hello World
@prod
Scenario: Hello to the world

- Relevant Issues : #2531 
- Relevant PRs : (optional)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
