### PR TITLE
#2530 Fix StringLogAppender leaks for MockHandler

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Logger.java
+++ b/karate-core/src/main/java/com/intuit/karate/Logger.java
@@ -48,6 +48,8 @@ public class Logger {
 
     private boolean appendOnly;
 
+    private boolean logOnly;
+
     public void setAppender(LogAppender appender) {
         this.appender = appender;
     }
@@ -68,6 +70,14 @@ public class Logger {
         return appendOnly;
     }
 
+    public void setLogOnly(boolean logOnly) {
+        this.logOnly = logOnly;
+    }
+
+    public boolean isLogOnly() {
+        return logOnly;
+    }
+
     public Logger(Class clazz) {
         LOGGER = LoggerFactory.getLogger(clazz);
     }
@@ -85,7 +95,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.trace(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -94,7 +106,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.debug(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -103,7 +117,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.info(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -112,7 +128,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.warn(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -121,7 +139,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.error(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 

--- a/karate-core/src/main/java/com/intuit/karate/core/MockHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/MockHandler.java
@@ -119,7 +119,8 @@ public class MockHandler implements ServerHandler {
         section.setIndex(-1); // TODO util for creating dummy scenario
         Scenario dummy = new Scenario(feature, section, -1);
         section.setScenario(dummy);
-        ScenarioRuntime runtime = new ScenarioRuntime(featureRuntime, dummy);        
+        ScenarioRuntime runtime = new ScenarioRuntime(featureRuntime, dummy);
+        runtime.logger.setLogOnly(true);
         runtime.engine.setVariable(PATH_MATCHES, (Function<String, Boolean>) this::pathMatches);
         runtime.engine.setVariable(PARAM_EXISTS, (Function<String, Boolean>) this::paramExists);
         runtime.engine.setVariable(PARAM_VALUE, (Function<String, String>) this::paramValue);


### PR DESCRIPTION
### Description

As the issue is reproducible by the long-running mock server, see: https://github.com/karatelabs/karate/issues/2530

**Memory analyzer**
<img width="874" alt="Screenshot 2567-03-18 at 00 56 49" src="https://github.com/karatelabs/karate/assets/52466150/42a54ee2-d1fb-418d-954f-4f409cbf6f26">

**The thread stack from GC.heap_dump**
```
armeria-common-worker-kqueue-3-2
  at java.lang.OutOfMemoryError.<init>()V (OutOfMemoryError.java:48)
  at java.util.Arrays.copyOf([BI)[B (Arrays.java:3745)
  at java.lang.AbstractStringBuilder.ensureCapacityInternal(I)V (AbstractStringBuilder.java:172)
  at java.lang.AbstractStringBuilder.append(Ljava/lang/String;)Ljava/lang/AbstractStringBuilder; (AbstractStringBuilder.java:538)
  at java.lang.StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder; (StringBuilder.java:178)
  at com.intuit.karate.shell.StringLogAppender.append(Ljava/lang/String;)V (StringLogAppender.java:56)
  at com.intuit.karate.Logger.append(Ljava/lang/String;)V (Logger.java:146)
  at com.intuit.karate.Logger.formatAndAppend(Ljava/lang/String;[Ljava/lang/Object;)V (Logger.java:140)
  at com.intuit.karate.Logger.debug(Ljava/lang/String;[Ljava/lang/Object;)V (Logger.java:97)
  at com.intuit.karate.core.MockHandler.isMatchingScenario(Lcom/intuit/karate/core/Scenario;Lcom/intuit/karate/core/ScenarioEngine;)Z (MockHandler.java:287)
  at com.intuit.karate.core.MockHandler.handle(Lcom/intuit/karate/http/Request;)Lcom/intuit/karate/http/Response; (MockHandler.java:185)
  at com.intuit.karate.http.HttpServerHandler.lambda$serve$0(Lcom/linecorp/armeria/server/ServiceRequestContext;Lcom/linecorp/armeria/common/AggregatedHttpRequest;)Lcom/linecorp/armeria/common/HttpResponse; (HttpServerHandler.java:59)
  at com.intuit.karate.http.HttpServerHandler$$Lambda$517.apply(Ljava/lang/Object;)Ljava/lang/Object; ()
  at java.util.concurrent.CompletableFuture$UniApply.tryFire(I)Ljava/util/concurrent/CompletableFuture; (CompletableFuture.java:642)
  at java.util.concurrent.CompletableFuture.postComplete()V (CompletableFuture.java:506)
  at java.util.concurrent.CompletableFuture.complete(Ljava/lang/Object;)Z (CompletableFuture.java:2073)
  at com.linecorp.armeria.common.stream.AggregationSupport.lambda$aggregate$2(Ljava/util/concurrent/CompletableFuture;Ljava/lang/Object;Ljava/lang/Throwable;)Ljava/lang/Object; (AggregationSupport.java:133)
  at com.linecorp.armeria.common.stream.AggregationSupport$$Lambda$516.apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; ()
  at java.util.concurrent.CompletableFuture.uniHandle(Ljava/lang/Object;Ljava/util/function/BiFunction;Ljava/util/concurrent/CompletableFuture$UniHandle;)Z (CompletableFuture.java:930)
  at java.util.concurrent.CompletableFuture$UniHandle.tryFire(I)Ljava/util/concurrent/CompletableFuture; (CompletableFuture.java:907)
  at java.util.concurrent.CompletableFuture.postComplete()V (CompletableFuture.java:506)
  at java.util.concurrent.CompletableFuture.complete(Ljava/lang/Object;)Z (CompletableFuture.java:2073)
  at com.linecorp.armeria.common.stream.StreamMessageCollector.onComplete()V (StreamMessageCollector.java:67)
  at com.linecorp.armeria.common.stream.CancellableStreamMessage$CloseEvent.notifySubscriber(Lcom/linecorp/armeria/common/stream/CancellableStreamMessage$SubscriptionImpl;Ljava/util/concurrent/CompletableFuture;)V (CancellableStreamMessage.java:258)
  at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent0(Lcom/linecorp/armeria/common/stream/CancellableStreamMessage$SubscriptionImpl;Lcom/linecorp/armeria/common/stream/CancellableStreamMessage$CloseEvent;)V (DefaultStreamMessage.java:303)
  at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent(Lcom/linecorp/armeria/common/stream/CancellableStreamMessage$SubscriptionImpl;Lcom/linecorp/armeria/common/stream/CancellableStreamMessage$CloseEvent;)V (DefaultStreamMessage.java:295)
  at com.linecorp.armeria.common.stream.DefaultStreamMessage.handleCloseEvent(Lcom/linecorp/armeria/common/stream/CancellableStreamMessage$SubscriptionImpl;Lcom/linecorp/armeria/common/stream/CancellableStreamMessage$CloseEvent;)V (DefaultStreamMessage.java:432)
  at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber0()V (DefaultStreamMessage.java:375)
  at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber()V (DefaultStreamMessage.java:331)
  at com.linecorp.armeria.common.stream.DefaultStreamMessage.addObjectOrEvent(Ljava/lang/Object;)V (DefaultStreamMessage.java:317)
  at com.linecorp.armeria.common.stream.DefaultStreamMessage.close()V (DefaultStreamMessage.java:439)
  at com.linecorp.armeria.server.Http1RequestDecoder.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (Http1RequestDecoder.java:328)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:442)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Lio/netty/channel/AbstractChannelHandlerContext;Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:420)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelHandlerContext; (AbstractChannelHandlerContext.java:412)
  at com.linecorp.armeria.server.HttpServerUpgradeHandler.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (HttpServerUpgradeHandler.java:228)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:444)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Lio/netty/channel/AbstractChannelHandlerContext;Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:420)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelHandlerContext; (AbstractChannelHandlerContext.java:412)
  at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelHandlerContext; (CombinedChannelDuplexHandler.java:436)
  at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(Lio/netty/channel/ChannelHandlerContext;Lio/netty/handler/codec/CodecOutputList;I)V (ByteToMessageDecoder.java:346)
  at io.netty.handler.codec.ByteToMessageDecoder.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (ByteToMessageDecoder.java:318)
  at io.netty.channel.CombinedChannelDuplexHandler.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (CombinedChannelDuplexHandler.java:251)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:442)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Lio/netty/channel/AbstractChannelHandlerContext;Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:420)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelHandlerContext; (AbstractChannelHandlerContext.java:412)
  at io.netty.handler.codec.ByteToMessageDecoder.handlerRemoved(Lio/netty/channel/ChannelHandlerContext;)V (ByteToMessageDecoder.java:266)
  at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(Lio/netty/channel/ChannelHandlerContext;Lio/netty/buffer/ByteBuf;Ljava/util/List;)V (ByteToMessageDecoder.java:536)
  at io.netty.handler.codec.ByteToMessageDecoder.callDecode(Lio/netty/channel/ChannelHandlerContext;Lio/netty/buffer/ByteBuf;Ljava/util/List;)V (ByteToMessageDecoder.java:468)
  at io.netty.handler.codec.ByteToMessageDecoder.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (ByteToMessageDecoder.java:290)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:444)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Lio/netty/channel/AbstractChannelHandlerContext;Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:420)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelHandlerContext; (AbstractChannelHandlerContext.java:412)
  at io.netty.handler.logging.LoggingHandler.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (LoggingHandler.java:280)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:442)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Lio/netty/channel/AbstractChannelHandlerContext;Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:420)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelHandlerContext; (AbstractChannelHandlerContext.java:412)
  at io.netty.handler.flush.FlushConsolidationHandler.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (FlushConsolidationHandler.java:152)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:442)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Lio/netty/channel/AbstractChannelHandlerContext;Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:420)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelHandlerContext; (AbstractChannelHandlerContext.java:412)
  at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V (DefaultChannelPipeline.java:1410)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:440)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(Lio/netty/channel/AbstractChannelHandlerContext;Ljava/lang/Object;)V (AbstractChannelHandlerContext.java:420)
  at io.netty.channel.DefaultChannelPipeline.fireChannelRead(Ljava/lang/Object;)Lio/netty/channel/ChannelPipeline; (DefaultChannelPipeline.java:919)
  at io.netty.channel.kqueue.AbstractKQueueStreamChannel$KQueueStreamUnsafe.readReady(Lio/netty/channel/kqueue/KQueueRecvByteAllocatorHandle;)V (AbstractKQueueStreamChannel.java:544)
  at io.netty.channel.kqueue.AbstractKQueueChannel$AbstractKQueueUnsafe.readReady(J)V (AbstractKQueueChannel.java:387)
  at io.netty.channel.kqueue.KQueueEventLoop.processReady(I)V (KQueueEventLoop.java:218)
  at io.netty.channel.kqueue.KQueueEventLoop.run()V (KQueueEventLoop.java:296)
  at io.netty.util.concurrent.SingleThreadEventExecutor$4.run()V (SingleThreadEventExecutor.java:997)
  at io.netty.util.internal.ThreadExecutorMap$2.run()V (ThreadExecutorMap.java:74)
  at io.netty.util.concurrent.FastThreadLocalRunnable.run()V (FastThreadLocalRunnable.java:30)
  at java.lang.Thread.run()V (Thread.java:829)
``` 

The StringBuilder object inside StringLogAppender has never been called collect() to de-refer all the string objects. it leads to memory leaks on the long-running mock server.

### Solutions
It seems that the mock usage does not need to use LogAppender, so MockHandler should have some ability to disable the appender.

**Before**
The memory trend increases over time and OOM at some point 
![monitor](https://github.com/karatelabs/karate/assets/52466150/1075d3b7-07fa-4b44-9928-57fdc5c791e0)

**After fixed**
The memory trend is now stable (the lowest memory usage after GC is keeping below 100MB)
![Screenshot 2567-03-18 at 00 45 01](https://github.com/karatelabs/karate/assets/52466150/979ecc44-124a-4738-a9eb-33404dbb5c2d)


- Relevant Issues : https://github.com/karatelabs/karate/issues/2530 https://github.com/karatelabs/karate/issues/2448
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
