### PR TITLE
2554 Add unique key codes for special characters

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/Keys.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/Keys.java
@@ -237,9 +237,6 @@ public class Keys {
         CODES.put('X', 88);
         CODES.put('Y', 89);
         CODES.put('Z', 90);
-        CODES.put('[', 91);
-        CODES.put('\\', 92);
-        CODES.put(']', 93);
         CODES.put('a', 97);
         CODES.put('b', 98);
         CODES.put('c', 99);
@@ -273,7 +270,15 @@ public class Keys {
         CODES.put('>', 160);
         CODES.put('{', 161);
         CODES.put('}', 162);
+        CODES.put('~', 171);
+        CODES.put('|', 172);
+        CODES.put('%', 175);
+        CODES.put('^', 176);
+        CODES.put('?', 191);
         CODES.put('`', 192);
+        CODES.put('[', 219);
+        CODES.put('\\', 220);
+        CODES.put(']', 221);
         CODES.put('\'', 222);
         CODES.put('@', 512);
         CODES.put(':', 513);


### PR DESCRIPTION
### Description
Moved characters `[`, `\`, and `]` from conflicting 90's codes to 200's.
Added characters `~ | % ^ ?` to remove warnings about unknown codes.
Selected codes use a combination of best guess and values from [toptal.com](https://www.toptal.com/developers/keycode/table).

- Relevant Issues : #2554 
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
