### PR TITLE
fix: gradle throw java.lang.ClassNotFoundException: mock.CatsKarateSimulation issue

### DIFF
--- a/examples/gatling/build.gradle
+++ b/examples/gatling/build.gradle
@@ -28,6 +28,9 @@ sourceSets {
             exclude '**/*.java'
             exclude '**/*.scala'
         }
+        scala {
+            srcDirs = ['src/test/java']
+        }
     }
 }
 

--- a/examples/gatling/src/test/java/mock/CatsGatlingSimulation.scala
+++ b/examples/gatling/src/test/java/mock/CatsGatlingSimulation.scala
@@ -1,5 +1,6 @@
 package mock
 
+import scala.language.postfixOps
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 

--- a/examples/gatling/src/test/java/mock/CatsKarateSimulation.scala
+++ b/examples/gatling/src/test/java/mock/CatsKarateSimulation.scala
@@ -1,5 +1,6 @@
 package mock
 
+import scala.language.postfixOps
 import com.intuit.karate.gatling.PreDef._
 import io.gatling.core.Predef._
 import scala.concurrent.duration._


### PR DESCRIPTION
### Description
Updated the Gradle config to resolve the ClassNotFoundException issue for the Gatling example

- Relevant Issues : [2562](https://github.com/karatelabs/karate/issues/2562)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
