### PR TITLE
Fixed readme for karate-gatling

### DIFF
--- a/karate-gatling/README.md
+++ b/karate-gatling/README.md
@@ -64,7 +64,7 @@ Refer to this [webinar recording](https://www.youtube.com/watch?v=WT4gg7Jutzg&t=
 
 ```xml
 <dependency>
-    <groupId>com.intuit.karate</groupId>
+    <groupId>io.karatelabs</groupId>
     <artifactId>karate-gatling</artifactId>
     <version>${karate.version}</version>
     <scope>test</scope>


### PR DESCRIPTION

### group id should be io.karatelabs

Current readme says group id `com.intuit.karate` which is incorrect as it won't resolve the dependency. Instead it should be 
`io.karatelabs`

- Relevant Issues : Current readme says group id `com.intuit.karate` which is incorrect as it won't resolve the dependency
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [X] Addition or Improvement of documentation
