### PR TITLE
handle mp4 like any other media in Embed toMap()

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Embed.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Embed.java
@@ -108,15 +108,8 @@ public class Embed {
 
     public Map toMap() {
         Map map = new HashMap(2);
-        if (resourceType == ResourceType.MP4) {
-            byte[] bytes = FileUtils.toBytes(getAsHtmlTag());
-            String base64 = Base64.getEncoder().encodeToString(bytes);
-            map.put("data", base64);
-            map.put("mime_type", ResourceType.HTML.contentType);
-        } else {
-            map.put("data", getBase64());
-            map.put("mime_type", resourceType.contentType);
-        }
+        map.put("data", getBase64());
+        map.put("mime_type", resourceType.contentType);
         return map;
     }
 


### PR DESCRIPTION
### Description

com.intuit.karate.core.Embed has a toMap() function with conditional logic for video/mp4 to to encode the HTML tag and text/html instead of encoding the video and using video/mp4. This works for the HTML reports, but not for the cucumber reports.

Removing the conditional logic for videos, and handling them the same way as every other content type to support cucumber json as well.

- Relevant Issues : https://github.com/karatelabs/karate/issues/2637 https://github.com/karatelabs/karate/issues/2121
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
