### PR TITLE
Add an optional environment variable for docker images in order to easily and globally configure additional startup flags

### DIFF
--- a/karate-docker/karate-chrome/entrypoint.sh
+++ b/karate-docker/karate-chrome/entrypoint.sh
@@ -16,7 +16,7 @@ if [ -z "$KARATE_SOCAT_START" ]
 	export KARATE_SOCAT_START="true"
 	export KARATE_CHROME_PORT="9223"
 fi
-[ -z "$KARATE_BROWSER_ADDITIONAL_FLAGS" ] && export KARATE_BROWSER_ADDITIONAL_FLAGS=""
+[ -z "$KARATE_CHROME_ADD_OPTIONS" ] && export KARATE_CHROME_ADD_OPTIONS=""
 [ -z "$KARATE_WIDTH" ] && export KARATE_WIDTH="1280"
 [ -z "$KARATE_HEIGHT" ] && export KARATE_HEIGHT="720"
 exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/karate-docker/karate-chrome/entrypoint.sh
+++ b/karate-docker/karate-chrome/entrypoint.sh
@@ -16,6 +16,7 @@ if [ -z "$KARATE_SOCAT_START" ]
 	export KARATE_SOCAT_START="true"
 	export KARATE_CHROME_PORT="9223"
 fi
+[ -z "$KARATE_BROWSER_ADDITIONAL_FLAGS" ] && export KARATE_BROWSER_ADDITIONAL_FLAGS=""
 [ -z "$KARATE_WIDTH" ] && export KARATE_WIDTH="1280"
 [ -z "$KARATE_HEIGHT" ] && export KARATE_HEIGHT="720"
 exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/karate-docker/karate-chrome/supervisord.conf
+++ b/karate-docker/karate-chrome/supervisord.conf
@@ -52,7 +52,7 @@ command=/usr/bin/google-chrome
     --force-device-scale-factor=1
     --remote-allow-origins=*
     --remote-debugging-port=%(ENV_KARATE_CHROME_PORT)s
-    %(ENV_KARATE_BROWSER_ADDITIONAL_FLAGS)s
+    %(ENV_KARATE_CHROME_ADD_OPTIONS)s
 autorestart=true
 priority=400
 

--- a/karate-docker/karate-chrome/supervisord.conf
+++ b/karate-docker/karate-chrome/supervisord.conf
@@ -52,6 +52,7 @@ command=/usr/bin/google-chrome
     --force-device-scale-factor=1
     --remote-allow-origins=*
     --remote-debugging-port=%(ENV_KARATE_CHROME_PORT)s
+    %(ENV_KARATE_BROWSER_ADDITIONAL_FLAGS)s
 autorestart=true
 priority=400
 

--- a/karate-docker/karate-chromium/entrypoint.sh
+++ b/karate-docker/karate-chromium/entrypoint.sh
@@ -16,7 +16,7 @@ if [ -z "$KARATE_SOCAT_START" ]
 	export KARATE_SOCAT_START="true"
 	export KARATE_CHROME_PORT="9223"
 fi
-[ -z "$KARATE_BROWSER_ADDITIONAL_FLAGS" ] && export KARATE_BROWSER_ADDITIONAL_FLAGS=""
+[ -z "$KARATE_CHROME_ADD_OPTIONS" ] && export KARATE_CHROME_ADD_OPTIONS=""
 [ -z "$KARATE_WIDTH" ] && export KARATE_WIDTH="1280"
 [ -z "$KARATE_HEIGHT" ] && export KARATE_HEIGHT="720"
 exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/karate-docker/karate-chromium/entrypoint.sh
+++ b/karate-docker/karate-chromium/entrypoint.sh
@@ -16,6 +16,7 @@ if [ -z "$KARATE_SOCAT_START" ]
 	export KARATE_SOCAT_START="true"
 	export KARATE_CHROME_PORT="9223"
 fi
+[ -z "$KARATE_BROWSER_ADDITIONAL_FLAGS" ] && export KARATE_BROWSER_ADDITIONAL_FLAGS=""
 [ -z "$KARATE_WIDTH" ] && export KARATE_WIDTH="1280"
 [ -z "$KARATE_HEIGHT" ] && export KARATE_HEIGHT="720"
 exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/karate-docker/karate-chromium/supervisord.conf
+++ b/karate-docker/karate-chromium/supervisord.conf
@@ -52,6 +52,7 @@ command=/usr/bin/chromium
     --force-device-scale-factor=1
     --remote-allow-origins=*
     --remote-debugging-port=%(ENV_KARATE_CHROME_PORT)s
+    %(ENV_KARATE_BROWSER_ADDITIONAL_FLAGS)s
 autorestart=true
 priority=400
 

--- a/karate-docker/karate-chromium/supervisord.conf
+++ b/karate-docker/karate-chromium/supervisord.conf
@@ -52,7 +52,7 @@ command=/usr/bin/chromium
     --force-device-scale-factor=1
     --remote-allow-origins=*
     --remote-debugging-port=%(ENV_KARATE_CHROME_PORT)s
-    %(ENV_KARATE_BROWSER_ADDITIONAL_FLAGS)s
+    %(ENV_KARATE_CHROME_ADD_OPTIONS)s
 autorestart=true
 priority=400
 

--- a/karate-docker/karate-firefox/entrypoint.sh
+++ b/karate-docker/karate-firefox/entrypoint.sh
@@ -16,6 +16,7 @@ if [ -z "$KARATE_SOCAT_START" ]
 	export KARATE_SOCAT_START="true"
 	export KARATE_CHROME_PORT="9223"
 fi
+[ -z "$KARATE_BROWSER_ADDITIONAL_FLAGS" ] && export KARATE_BROWSER_ADDITIONAL_FLAGS=""
 [ -z "$KARATE_WIDTH" ] && export KARATE_WIDTH="1280"
 [ -z "$KARATE_HEIGHT" ] && export KARATE_HEIGHT="720"
 exec /usr/bin/supervisord

--- a/karate-docker/karate-firefox/entrypoint.sh
+++ b/karate-docker/karate-firefox/entrypoint.sh
@@ -16,7 +16,7 @@ if [ -z "$KARATE_SOCAT_START" ]
 	export KARATE_SOCAT_START="true"
 	export KARATE_CHROME_PORT="9223"
 fi
-[ -z "$KARATE_BROWSER_ADDITIONAL_FLAGS" ] && export KARATE_BROWSER_ADDITIONAL_FLAGS=""
+[ -z "$KARATE_CHROME_ADD_OPTIONS" ] && export KARATE_CHROME_ADD_OPTIONS=""
 [ -z "$KARATE_WIDTH" ] && export KARATE_WIDTH="1280"
 [ -z "$KARATE_HEIGHT" ] && export KARATE_HEIGHT="720"
 exec /usr/bin/supervisord

--- a/karate-docker/karate-firefox/supervisord.conf
+++ b/karate-docker/karate-firefox/supervisord.conf
@@ -45,6 +45,7 @@ command=/usr/bin/firefox
     --window-size=%(ENV_KARATE_WIDTH)s,%(ENV_KARATE_HEIGHT)s
     --force-device-scale-factor=1
     --remote-debugging-port=%(ENV_KARATE_CHROME_PORT)s
+    %(ENV_KARATE_BROWSER_ADDITIONAL_FLAGS)s
 autorestart=true
 priority=400
 

--- a/karate-docker/karate-firefox/supervisord.conf
+++ b/karate-docker/karate-firefox/supervisord.conf
@@ -45,7 +45,7 @@ command=/usr/bin/firefox
     --window-size=%(ENV_KARATE_WIDTH)s,%(ENV_KARATE_HEIGHT)s
     --force-device-scale-factor=1
     --remote-debugging-port=%(ENV_KARATE_CHROME_PORT)s
-    %(ENV_KARATE_BROWSER_ADDITIONAL_FLAGS)s
+    %(ENV_KARATE_CHROME_ADD_OPTIONS)s
 autorestart=true
 priority=400
 


### PR DESCRIPTION

### Description

Add an optional environment variable in karate docker images that when set add its value as additional flags to browsers' startup command.

- Relevant Issues : #2648
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
