### PR TITLE
Support for Case-Sensitive HTTP Headers in Karate Mock Server

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -132,6 +132,9 @@ public class Main implements Callable<Void> {
     @Option(names = {"-H", "--hook"}, split = ",", description = "class name of a RuntimeHook (or RuntimeHookFactory) to add")
     List<String> hookFactoryClassNames;
 
+    @Option(names = {"--keepOriginalHeaders"}, description = "Keeping original headers given in the mock feature or configure")
+    boolean keepOriginalHeaders;
+
     //==========================================================================
     //
     public void addPath(String path) {
@@ -372,7 +375,8 @@ public class Main implements Callable<Void> {
             RequestHandler handler = new RequestHandler(config);
             HttpServer.Builder builder = HttpServer
                     .handler(handler)
-                    .corsEnabled(true);
+                    .corsEnabled(true)
+                    .keepOriginalHeaders(keepOriginalHeaders);
             if (ssl) {
                 builder.https(port)
                         .certFile(cert)
@@ -399,7 +403,8 @@ public class Main implements Callable<Void> {
             });
             HttpServer.Builder builder = HttpServer.config(config)
                     .local(false)
-                    .corsEnabled(true);
+                    .corsEnabled(true)
+                    .keepOriginalHeaders(keepOriginalHeaders);
             if (ssl) {
                 builder.https(port);
             } else {
@@ -414,7 +419,8 @@ public class Main implements Callable<Void> {
                 .pathPrefix(prefix)
                 .certFile(cert)
                 .keyFile(key)
-                .watch(watch);
+                .watch(watch)
+                .keepOriginalHeaders(keepOriginalHeaders);
         if (ssl) {
             builder.https(port);
         } else {

--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -132,7 +132,7 @@ public class Main implements Callable<Void> {
     @Option(names = {"-H", "--hook"}, split = ",", description = "class name of a RuntimeHook (or RuntimeHookFactory) to add")
     List<String> hookFactoryClassNames;
 
-    @Option(names = {"--keepOriginalHeaders"}, description = "Keeping original headers given in the mock feature or configure")
+    @Option(names = {"--keep-original-headers"}, description = "keeping original headers given in the mock scenario or configure")
     boolean keepOriginalHeaders;
 
     //==========================================================================

--- a/karate-core/src/main/java/com/intuit/karate/http/GenericHttpHeaderTracking.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/GenericHttpHeaderTracking.java
@@ -1,0 +1,28 @@
+package com.intuit.karate.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GenericHttpHeaderTracking implements HttpHeaderTracking {
+
+    private final Map<String, String> httpHeaders = new HashMap<>();
+
+    @Override
+    public void putHeader(String originalHeader) {
+        if (originalHeader == null) {
+            return;
+        }
+
+        httpHeaders.put(originalHeader.toLowerCase(), originalHeader);
+    }
+
+    @Override
+    public String getOriginalHeader(String header) {
+        if (header == null) {
+            return null;
+        }
+
+        return httpHeaders.getOrDefault(header.toLowerCase(), header);
+    }
+
+}

--- a/karate-core/src/main/java/com/intuit/karate/http/GenericHttpHeaderTracking.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/GenericHttpHeaderTracking.java
@@ -5,24 +5,24 @@ import java.util.Map;
 
 public class GenericHttpHeaderTracking implements HttpHeaderTracking {
 
-    private final Map<String, String> httpHeaders = new HashMap<>();
+    private final Map<String, String> httpHeaderReference = new HashMap<>();
 
     @Override
-    public void putHeader(String originalHeader) {
+    public void putHeaderReference(String originalHeader) {
         if (originalHeader == null) {
             return;
         }
 
-        httpHeaders.put(originalHeader.toLowerCase(), originalHeader);
+        httpHeaderReference.put(originalHeader.toLowerCase(), originalHeader);
     }
 
     @Override
-    public String getOriginalHeader(String header) {
-        if (header == null) {
+    public String getOriginalHeader(String headerReference) {
+        if (headerReference == null) {
             return null;
         }
 
-        return httpHeaders.getOrDefault(header.toLowerCase(), header);
+        return httpHeaderReference.getOrDefault(headerReference.toLowerCase(), headerReference);
     }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpHeaderTracking.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpHeaderTracking.java
@@ -1,0 +1,9 @@
+package com.intuit.karate.http;
+
+public interface HttpHeaderTracking {
+
+    void putHeader(String originalHeader);
+
+    String getOriginalHeader(String header);
+
+}

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpHeaderTracking.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpHeaderTracking.java
@@ -2,8 +2,8 @@ package com.intuit.karate.http;
 
 public interface HttpHeaderTracking {
 
-    void putHeader(String originalHeader);
+    void putHeaderReference(String originalHeader);
 
-    String getOriginalHeader(String header);
+    String getOriginalHeader(String headerReference);
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpServerHandler.java
@@ -48,8 +48,11 @@ public class HttpServerHandler implements HttpService {
 
     private final ServerHandler handler;
 
-    public HttpServerHandler(ServerHandler handler) {
+    private final HttpHeaderTracking httpHeaderTracking;
+
+    public HttpServerHandler(ServerHandler handler, HttpHeaderTracking httpHeaderTracking) {
         this.handler = handler;
+        this.httpHeaderTracking = httpHeaderTracking;
     }
 
     @Override
@@ -94,13 +97,43 @@ public class HttpServerHandler implements HttpService {
         ResponseHeadersBuilder rhb = ResponseHeaders.builder(response.getStatus());
         Map<String, List<String>> headers = response.getHeaders();
         if (headers != null) {
-            headers.forEach((k, v) -> rhb.add(k, v));
+            headers.forEach((k, v) -> {
+                rhb.add(k, v);
+                if (httpHeaderTracking != null) {
+                    httpHeaderTracking.putHeader(k);
+                }
+            });
         }
         HttpResponse hr = HttpResponse.of(rhb.build(), HttpData.wrap(body));
         if (response.getDelay() > 0) {
             return HttpResponse.delayed(hr, Duration.ofMillis(response.getDelay()), ctx.eventLoop());
         } else {
             return hr;
+        }
+    }
+
+    public static class Builder {
+
+        private ServerHandler handler;
+
+        private HttpHeaderTracking httpHeaderTracking;
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Builder handler(ServerHandler value) {
+            handler = value;
+            return this;
+        }
+
+        public Builder httpHeaderTracking(HttpHeaderTracking value) {
+            httpHeaderTracking = value;
+            return this;
+        }
+
+        public HttpServerHandler build() {
+            return new HttpServerHandler(handler, httpHeaderTracking);
         }
     }
 

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpServerHandler.java
@@ -100,7 +100,7 @@ public class HttpServerHandler implements HttpService {
             headers.forEach((k, v) -> {
                 rhb.add(k, v);
                 if (httpHeaderTracking != null) {
-                    httpHeaderTracking.putHeader(k);
+                    httpHeaderTracking.putHeaderReference(k);
                 }
             });
         }

--- a/karate-core/src/test/java/com/intuit/karate/MainTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/MainTest.java
@@ -24,7 +24,7 @@ class MainTest {
 
     @Test
     void testKeepOriginalHeaders() {
-        Main options = Main.parseKarateArgs(List.of("--keepOriginalHeaders"));
+        Main options = Main.parseKarateArgs(List.of("--keep-original-headers"));
         assertEquals(true, options.keepOriginalHeaders);
     }
 }

--- a/karate-core/src/test/java/com/intuit/karate/MainTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/MainTest.java
@@ -21,5 +21,10 @@ class MainTest {
         Main options = Main.parseKarateArgs(List.of("-d"));
         assertEquals(0, options.debugPort);
     }
-    
+
+    @Test
+    void testKeepOriginalHeaders() {
+        Main options = Main.parseKarateArgs(List.of("--keepOriginalHeaders"));
+        assertEquals(true, options.keepOriginalHeaders);
+    }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
@@ -36,6 +36,16 @@ class HttpMockHandlerTest {
         return http;
     }
 
+    HttpRequestBuilder handleWithOriginalHeaders() {
+        handler = new MockHandler(mock.build());
+        server = HttpServer.handler(handler).keepOriginalHeaders(true).build();
+        ScenarioEngine se = ScenarioEngine.forTempUse(HttpClientFactory.DEFAULT);
+        ApacheHttpClient client = new ApacheHttpClient(se);
+        http = new HttpRequestBuilder(client);
+        http.url("http://localhost:" + server.getPort());
+        return http;
+    }
+
     FeatureBuilder background(String... lines) {
         mock = FeatureBuilder.background(lines);
         return mock;
@@ -96,4 +106,18 @@ class HttpMockHandlerTest {
         match(response.getHeader("Content-Type"), "text/html");
     }
 
+    @Test
+    void testKeepOriginalResponseHeaders() {
+        background("configure responseHeaders = { 'X-Special-Header': 'test1' }")
+                .scenario(
+                        "pathMatches('/hello')",
+                        "def responseHeaders = { 'X-Custom-Header': 'test2' }",
+                        "def response = ''");
+        response = handleWithOriginalHeaders().path("/hello").invoke("get");
+        match(response.getHeader("X-Special-Header"), "test1");
+        match(response.getHeader("X-Custom-Header"), "test2");
+
+        matchContains(response.getHeaders().keySet(), "X-Special-Header");
+        matchContains(response.getHeaders().keySet(), "X-Custom-Header");
+    }
 }

--- a/karate-core/src/test/java/com/intuit/karate/http/GenericHttpHeaderTrackingTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/http/GenericHttpHeaderTrackingTest.java
@@ -11,20 +11,20 @@ class GenericHttpHeaderTrackingTest {
     void testPutHeader() {
         String header = "X-Special-Header";
 
-        Assertions.assertDoesNotThrow(() -> httpHeaderTracking.putHeader(header));
+        Assertions.assertDoesNotThrow(() -> httpHeaderTracking.putHeaderReference(header));
     }
 
     @Test
     void testPutHeaderWithNull() {
         String header = null;
 
-        Assertions.assertDoesNotThrow(() -> httpHeaderTracking.putHeader(header));
+        Assertions.assertDoesNotThrow(() -> httpHeaderTracking.putHeaderReference(header));
     }
 
     @Test
     void testGetOriginalHeader() {
         String header = "X-Special-Header";
-        httpHeaderTracking.putHeader(header);
+        httpHeaderTracking.putHeaderReference(header);
 
         String result = httpHeaderTracking.getOriginalHeader(header);
         Assertions.assertEquals(header, result);

--- a/karate-core/src/test/java/com/intuit/karate/http/GenericHttpHeaderTrackingTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/http/GenericHttpHeaderTrackingTest.java
@@ -1,11 +1,17 @@
 package com.intuit.karate.http;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class GenericHttpHeaderTrackingTest {
 
-    private final GenericHttpHeaderTracking httpHeaderTracking = new GenericHttpHeaderTracking();
+    private GenericHttpHeaderTracking httpHeaderTracking;
+
+    @BeforeEach
+    void beforeEach() {
+        httpHeaderTracking = new GenericHttpHeaderTracking();
+    }
 
     @Test
     void testPutHeader() {

--- a/karate-core/src/test/java/com/intuit/karate/http/GenericHttpHeaderTrackingTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/http/GenericHttpHeaderTrackingTest.java
@@ -1,0 +1,48 @@
+package com.intuit.karate.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GenericHttpHeaderTrackingTest {
+
+    private final GenericHttpHeaderTracking httpHeaderTracking = new GenericHttpHeaderTracking();
+
+    @Test
+    void testPutHeader() {
+        String header = "X-Special-Header";
+
+        Assertions.assertDoesNotThrow(() -> httpHeaderTracking.putHeader(header));
+    }
+
+    @Test
+    void testPutHeaderWithNull() {
+        String header = null;
+
+        Assertions.assertDoesNotThrow(() -> httpHeaderTracking.putHeader(header));
+    }
+
+    @Test
+    void testGetOriginalHeader() {
+        String header = "X-Special-Header";
+        httpHeaderTracking.putHeader(header);
+
+        String result = httpHeaderTracking.getOriginalHeader(header);
+        Assertions.assertEquals(header, result);
+    }
+
+    @Test
+    void testGetOriginalHeaderWithoutExistingHeaderInTracking() {
+        String header = "X-Special-Header";
+
+        String result = httpHeaderTracking.getOriginalHeader(header);
+        Assertions.assertEquals(header, result);
+    }
+
+    @Test
+    void testGetOriginalHeaderWithNull() {
+        String header = null;
+
+        String result = httpHeaderTracking.getOriginalHeader(header);
+        Assertions.assertNull(result);
+    }
+}


### PR DESCRIPTION
### Description

Dear Karate Mock Team,

I truly appreciate your time and effort in developing and maintaining the Karate mock server as an open-source project.

Recently, I needed to integrate the mock server for testing with a legacy system that requires HTTP/1 headers or specific header formats. For example, the system expects the header exactly as "X-Special-Header" and not "x-special-header" to function correctly.

I noticed that even after configuring the `lowerCaseResponseHeaders` property to false, the headers were still converted to lowercase due to Armeria server’s adherence to HTTP/2/gRPC standards.

Fortunately, the Armeria team has provided an interface for mapping HTTP/2 headers to HTTP/1 headers [Armeria Issue #3196](https://github.com/line/armeria/issues/3196)., but it requires manual mapping. My initial thought was to provide an option for specifying HTTP/1 header configurations, for example:
```
java -jar karate.jar --http1header='X-Special-Header'
```
This option could then be used to map headers in the Armeria server like so:
```
sb.http1HeaderNaming(http2Header -> http1Headers.getOrDefault(http2Header, http2Header))
```
However, I believe it would be a better solution to collect the original HTTP headers directly from the provided `Scenario` and use them as references for mapping, rather than manually specifying each header through configuration options.

I have made an initial attempt at implementing this solution, and it worked as I tested myself. However, this may not work when performing high TPS or load testing. My solution currently uses the same `httpHeaderReference` from `HttpHeaderTracking`, but different features might require different header formats. For instance:
```
Scenario: pathMatches('/api/test1')  
    * def responseHeaders = { "X-Special-Header": "test" }  

Scenario: pathMatches('/api/test2')  
    * def responseHeaders = { "X-special-header": "test" }  
```
In such cases, headers may override each other since HTTP/2 uses lowercase for mapping. While we could add the scenario as a prefix to the `httpHeaderReference`, I believe it's a rare situation to have different scenarios with different header formats. Therefore, I have provided a simpler solution for now.

Thank you for your attention, and I look forward to hearing your thoughts on this.

Best regards,

- Relevant Issues : 
  - https://github.com/karatelabs/karate/issues/2654
  - https://github.com/line/armeria/issues/3196
- Type of change :
  - [x] New feature