### PR TITLE
Upgrade json-smart from 2.5.1 to 2.5.2 fixing CVE-2024-57699

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.5.1</version>
+            <version>2.5.2</version>
         </dependency>                                                                                                                                                           													                      
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
For details about CVE-2024-57699 see
https://github.com/netplex/json-smart-v2/releases/tag/2.5.2

Karate uses `new JsonSmartJsonProvider()` that uses `JSONParser.MODE_PERMISSIVE` that includes `LIMIT_JSON_DEPTH` and therefore is not affected by CVE-2024-57699:
* https://github.com/karatelabs/karate/blob/v1.5.2.RC2/karate-core/src/main/java/com/intuit/karate/JsonUtils.java#L74
* https://github.com/json-path/JsonPath/blob/json-path-2.9.0/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonSmartJsonProvider.java#L39
* https://github.com/netplex/json-smart-v2/blob/2.5.1/json-smart/src/main/java/net/minidev/json/parser/JSONParser.java#L110

However, other projects that use Karate may directly call `new JsonSmartJsonProvider(int parseMode)` with one of the other default modes and are vulnerable.

Therefore Karate should ship the fixed version.

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : #2662
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Dependency update fixing CVE
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
