### PR TITLE
Issue 2482: accept empty cookies names

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/ApacheHttpClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/ApacheHttpClient.java
@@ -316,9 +316,11 @@ public class ApacheHttpClient implements HttpClient, HttpRequestInterceptor {
         Set<String> alreadyMerged = new HashSet(requestCookieHeaders.length);
         for (Header ch : requestCookieHeaders) {
             String requestCookieValue = ch.getValue();
-            io.netty.handler.codec.http.cookie.Cookie c = ClientCookieDecoder.LAX.decode(requestCookieValue);            
-            mergedCookieValues.add(requestCookieValue);
-            alreadyMerged.add(c.name());
+            io.netty.handler.codec.http.cookie.Cookie c = ClientCookieDecoder.LAX.decode(requestCookieValue);
+            if (c != null) {
+                mergedCookieValues.add(requestCookieValue);
+                alreadyMerged.add(c.name());
+            }
         }        
         for (Cookie c : storedCookies) {
             if (c.getValue() != null) {

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
@@ -332,6 +332,52 @@ class KarateHttpMockHandlerTest {
                 "method get"
         );
         matchVar("response", "success");
-    }    
+    }
+
+    @Test
+    void testEmptyCookieNameSet() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def responseHeaders = {'Set-Cookie': ' '}"
+
+        );
+        startMockServer();
+        run(
+                urlStep(),
+                "path 'hello'",
+                "method get"
+        );
+        matchVarContains("responseHeaders", "{ set-cookie: [''] }");
+    }
+
+    @Test
+    void testEmptyCookieNameAndEmptyAttributesSet() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def responseHeaders = {'Set-Cookie': ';'}"
+
+        );
+        startMockServer();
+        run(
+                urlStep(),
+                "path 'hello'",
+                "method get"
+        );
+        matchVarContains("responseHeaders", "{ set-cookie: [';'] }");
+    }
+
+    @Test
+    void testEmptyCookieNameAndNonEmptyAttributeSet() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def responseHeaders = {'Set-Cookie': '; SameSite=Strict'}");
+        startMockServer();
+        run(
+                urlStep(),
+                "path 'hello'",
+                "method get"
+        );
+        matchVarContains("responseHeaders", "{ set-cookie: ['; SameSite=Strict'] }");
+    }
 
 }


### PR DESCRIPTION
### Description

The change is to skip merging logic for cookies without a name to avoid NPE. Also, we can not merge a cookie if the cookie's name is unavailable.

According to [rfc6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2), SetCookies processing logic does follow several steps to parse cookies; in general, a client should ignore the cookie when the name is not available  `If the name-value-pair string lacks a %x3D ("=") character,
       ignore the set-cookie-string entirely.`

There is one edge case related to redirect which this change does not cover:
1. /path1 `'Set-Cookie': '; foo1=bar1'` -> redirects to /path2
2. /path2 `'Set-Cookie': 'foo2=bar2'`

This will result in
```
set-cookie: 'foo2=bar2'
```

instead of

```
set-cookie: ['; foo1=bar1',  'foo2=bar2']
```

In this case, because  Apache HTTP client correctly implements RFC cookies for /path1, the `foo1=bar1` won't be set as the name for the cookie is null.
On the other hand, the Netty ClientCookieDecoder would  for the same cookie parse it with the name `foo1` and value `bar1.`

So this
1. /path1 `'Set-Cookie': 'foo1=bar1'` -> redirects to /path2
2. /path2 `'Set-Cookie': '; foo2=bar2'`

Will result in a different result
`['foo1=bar1; Domain=localhost', '; foo2=bar2']`

This makes the behaviour inconsistent; however, we would need to use the same cookie parser for the original cookie store and redirect to make the behaviour the same

- Relevant Issues : https://github.com/karatelabs/karate/issues/2482
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
