### PR TITLE
Add WebSocket frame aggregation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4269,6 +4269,7 @@ Karate also has built-in support for [websocket](http://www.websocket.org) that 
   * `subProtocol` - in case the server expects it
   * `headers` - another JSON of key-value pairs
   * `maxPayloadSize` - this defaults to 4194304 (bytes, around 4 MB)
+  * `useFrameAggregation` - (Boolean) defaults to `false`.  Can be enabled to aggregate multiple frames if the server sends multiple frames for a single payload.
 
 These will init a websocket client for the given `url` and optional `subProtocol`. You can call `send()` on the returned object to send a message.
 

--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -2154,6 +2154,7 @@ For more control or custom options, the `start()` method takes a `Map<String, Ob
 * `executable` - (String) path to the Chrome executable or batch file that starts Chrome
 * `headless` - (Boolean) if headless
 * `maxPayloadSize` - (Integer) defaults to 4194304 (bytes, around 4 MB), but you can override it if you deal with very large output / binary payloads
+* `useFrameAggregation` - (Boolean) defaults to `false`.  Can be enabled to aggregate multiple frames if the server sends multiple frames for a single payload.
 
 ## `driver.screenshotFull()`
 Only supported for driver type [`chrome`](#driver-types). See [Chrome Java API](#chrome-java-api). This will snapshot the entire page, not just what is visible in the viewport.

--- a/karate-core/src/main/java/com/intuit/karate/http/WebSocketClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/WebSocketClient.java
@@ -46,6 +46,7 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.ssl.SslContext;
@@ -147,6 +148,9 @@ public class WebSocketClient implements WebSocketListener {
                             p.addLast(new HttpClientCodec());
                             p.addLast(new HttpObjectAggregator(8192));
                             p.addLast(WebSocketClientCompressionHandler.INSTANCE);
+                            if (options.getUseFrameAggregation()) {
+                                p.addLast(new WebSocketFrameAggregator(options.getMaxPayloadSize()));
+                            }
                             p.addLast(handler);
                         }
                     });

--- a/karate-core/src/main/java/com/intuit/karate/http/WebSocketOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/WebSocketOptions.java
@@ -42,6 +42,7 @@ public class WebSocketOptions {
     private Function<byte[], Boolean> binaryHandler;
     private Map<String, Object> headers;
     private int maxPayloadSize = 4194304;
+    private boolean useFrameAggregation = false;
 
     public WebSocketOptions(String url) {
         this(url, null);
@@ -57,6 +58,12 @@ public class WebSocketOptions {
             if (temp != null) {
                 maxPayloadSize = temp;
             }
+
+            Boolean tempUseFrameAggregation = (Boolean) options.get("useFrameAggregation");
+            if (tempUseFrameAggregation != null) {
+                useFrameAggregation = tempUseFrameAggregation;
+            }
+
             headers = (Map) options.get("headers");
         }
     }
@@ -120,4 +127,7 @@ public class WebSocketOptions {
         this.maxPayloadSize = maxPayloadSize;
     }
 
+    public boolean getUseFrameAggregation() { return this.useFrameAggregation; }
+
+    public void setUseFrameAggregation(boolean useFrameAggregation) { this.useFrameAggregation = useFrameAggregation; }
 }

--- a/karate-demo/src/test/java/demo/websocket/echo.feature
+++ b/karate-demo/src/test/java/demo/websocket/echo.feature
@@ -16,7 +16,7 @@ Scenario: binary message
     And def socket = karate.webSocketBinary('ws://echo.websocket.org')
     And bytes data = read('../upload/test.pdf')
     When socket.sendBytes(data)
-    And listen (5000
+    And listen 5000
     # the result data-type is byte-array, but this comparison works
     Then match listenResult == read('../upload/test.pdf')
 


### PR DESCRIPTION
### Description

Introduced the `useFrameAggregation` option to enable aggregation of fragmented WebSocket frames. Updated `WebSocketClient` to conditionally include `WebSocketFrameAggregator` in the Netty pipeline. Enhanced `WebSocketOptions` to support the new option with a default value of `false`. Updated documentation in `README.md` to reflect the changes. Improved syntax consistency in `echo.feature` test file.

- Relevant Issues : #2692 
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [X] Addition or Improvement of documentation
