### PR TITLE
Fix forward slashes being turned into escape

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
@@ -64,6 +64,8 @@ public class JsonUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(JsonUtils.class);
 
+    private static final JSONStyle JSON_STYLE = new JSONStyle(JSONStyle.FLAG_PROTECT_4WEB);
+
     private JsonUtils() {
         // only static methods
     }
@@ -108,7 +110,7 @@ public class JsonUtils {
         JSONParser jp = new JSONParser(JSONParser.MODE_PERMISSIVE);
         try {
             Object o = jp.parse(raw);
-            return JSONValue.toJSONString(o);
+            return JSONValue.toJSONString(o, JSON_STYLE);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -121,7 +123,7 @@ public class JsonUtils {
     public static String toJson(Object o, boolean pretty) {
         if (!pretty) { // TODO use JSONStyleIdent in json-smart 2.4
             try {
-                return JSONValue.toJSONString(o);
+                return JSONValue.toJSONString(o, JSON_STYLE);
             } catch (Throwable t) {
                 logger.warn("object to json serialization failure, trying alternate approach: {}", t.getMessage());
             }

--- a/karate-core/src/main/java/com/intuit/karate/core/Variable.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Variable.java
@@ -228,11 +228,11 @@ public class Variable {
             case LIST:
             case MAP:
                 try {
-                return JsonUtils.toJson(value);
-            } catch (Throwable t) {
-                logger.warn("conversion to json string failed, will attempt to use fall-back approach: {}", t.getMessage());
-                return JsonUtils.toJsonSafe(value, false);
-            }
+                    return JsonUtils.toJson(value);
+                } catch (Throwable t) {
+                    logger.warn("conversion to json string failed, will attempt to use fall-back approach: {}", t.getMessage());
+                    return JsonUtils.toJsonSafe(value, false);
+                }
             case XML:
                 return XmlUtils.toString(getValue());
             default:

--- a/karate-core/src/test/java/com/intuit/karate/JsonUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/JsonUtilsTest.java
@@ -22,7 +22,7 @@ class JsonUtilsTest {
     @Test
     void testParse() {
         String temp = JsonUtils.toStrictJson("{redirect:{url:'/index'}}");
-        assertEquals(temp, "{\"redirect\":{\"url\":\"\\/index\"}}");
+        assertEquals("{\"redirect\":{\"url\":\"/index\"}}", temp);
     }
 
     @Test

--- a/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
@@ -130,7 +130,7 @@ class HttpMockHandlerTest {
                 .scenario(
                         "pathMatches('/hello')",
                         "def response = { 'url': 'https://test123' }");
-        response = handleWithOriginalHeaders().path("/hello").invoke("get");
+        response = handle().path("/hello").invoke("get");
         match(response.getBody(), "{\"url\":\"https://test123\"}".getBytes());
     }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
@@ -2,6 +2,7 @@ package com.intuit.karate.core;
 
 import com.intuit.karate.Constants;
 import static com.intuit.karate.TestUtils.*;
+
 import com.intuit.karate.http.ApacheHttpClient;
 import com.intuit.karate.http.HttpClientFactory;
 import com.intuit.karate.http.HttpRequestBuilder;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -119,5 +122,15 @@ class HttpMockHandlerTest {
 
         matchContains(response.getHeaders().keySet(), "X-Special-Header");
         matchContains(response.getHeaders().keySet(), "X-Custom-Header");
+    }
+
+    @Test
+    void testResponseHavingForwardSlashes() {
+        background()
+                .scenario(
+                        "pathMatches('/hello')",
+                        "def response = { 'url': 'https://test123' }");
+        response = handleWithOriginalHeaders().path("/hello").invoke("get");
+        match(response.getBody(), "{\"url\":\"https://test123\"}".getBytes());
     }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/HttpMockHandlerTest.java
@@ -2,7 +2,6 @@ package com.intuit.karate.core;
 
 import com.intuit.karate.Constants;
 import static com.intuit.karate.TestUtils.*;
-
 import com.intuit.karate.http.ApacheHttpClient;
 import com.intuit.karate.http.HttpClientFactory;
 import com.intuit.karate.http.HttpRequestBuilder;
@@ -12,8 +11,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.charset.StandardCharsets;
 
 /**
  *

--- a/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
@@ -27,6 +27,8 @@ public class StepRuntimeTest {
     @MethodSource("testParameters")
     public void testConversionMethodToStringAndBack(String methodSignature, Class<?> methodClass, Method method, List<String> args, String karateExpr) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         StepRuntime.MethodMatch methodMatch = StepRuntime.MethodMatch.getBySignatureAndArgs(methodSignature);
+        System.out.println("methodSignature " + methodSignature);
+        System.out.println("methodMatch " + methodMatch.toString());
 
         Assertions.assertNotNull(methodMatch);
         Assertions.assertEquals(method, methodMatch.method);
@@ -101,7 +103,7 @@ public class StepRuntimeTest {
                         com.intuit.karate.ScenarioActions.class.getMethod("print", String.class),
                         new ArrayList<String>() { { add("\"name:\", name"); }},
                         "print \"name:\", name"),
-                Arguments.of("com.intuit.karate.ScenarioActions.print(java.lang.String) [\"'test with\\/slash'\"]", // JSON escapes forward slash
+                Arguments.of("com.intuit.karate.ScenarioActions.print(java.lang.String) [\"'test with/slash'\"]", // JSON escapes forward slash
                         com.intuit.karate.ScenarioActions.class,
                         com.intuit.karate.ScenarioActions.class.getMethod("print", String.class),
                         new ArrayList<String>() { { add("'test with/slash'"); }},

--- a/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
@@ -27,8 +27,6 @@ public class StepRuntimeTest {
     @MethodSource("testParameters")
     public void testConversionMethodToStringAndBack(String methodSignature, Class<?> methodClass, Method method, List<String> args, String karateExpr) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         StepRuntime.MethodMatch methodMatch = StepRuntime.MethodMatch.getBySignatureAndArgs(methodSignature);
-        System.out.println("methodSignature " + methodSignature);
-        System.out.println("methodMatch " + methodMatch.toString());
 
         Assertions.assertNotNull(methodMatch);
         Assertions.assertEquals(method, methodMatch.method);

--- a/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/StepRuntimeTest.java
@@ -101,7 +101,7 @@ public class StepRuntimeTest {
                         com.intuit.karate.ScenarioActions.class.getMethod("print", String.class),
                         new ArrayList<String>() { { add("\"name:\", name"); }},
                         "print \"name:\", name"),
-                Arguments.of("com.intuit.karate.ScenarioActions.print(java.lang.String) [\"'test with/slash'\"]", // JSON escapes forward slash
+                Arguments.of("com.intuit.karate.ScenarioActions.print(java.lang.String) [\"'test with/slash'\"]", // JSON with forward slash
                         com.intuit.karate.ScenarioActions.class,
                         com.intuit.karate.ScenarioActions.class.getMethod("print", String.class),
                         new ArrayList<String>() { { add("'test with/slash'"); }},


### PR DESCRIPTION
### Description
According to the issue I have reported, this pull request attempts to fix it by applying JSON style to prevent escaping forward slashes. However, I realize this change may break existing users who rely on the escaped form \/, as their responses and behavior would now be different.

- Relevant Issues : (compulsory)
   - https://github.com/karatelabs/karate/issues/2713
- Type of change :
  - [x] Bug fix for existing feature
