### PR TITLE
Add karate-js-test262 conformance harness and structured error names

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -1,0 +1,81 @@
+name: test262
+
+# Manually-triggered ECMAScript conformance run for karate-js.
+# Clones tc39/test262 at the pinned SHA, runs the full suite, generates the
+# HTML report, and uploads both the report and results.jsonl as artifacts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Restrict to a path glob (empty = full suite)"
+        required: false
+        default: ""
+      timeout_ms:
+        description: "Per-test watchdog (ms)"
+        required: false
+        default: "10000"
+
+permissions: read-all
+
+jobs:
+  test262:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Fetch test262
+        run: |
+          chmod +x karate-js-test262/fetch-test262.sh
+          karate-js-test262/fetch-test262.sh
+
+      # Single Maven invocation: install karate-js into the local repo (so the
+      # test262 module can resolve it), then compile the test262 module. Using
+      # -am -pl builds only what's needed.
+      - name: Build reactor (karate-js + test262 harness)
+        run: mvn -B -ntp -pl karate-js-test262 -am install -DskipTests
+
+      - name: Run test262 suite
+        working-directory: karate-js-test262
+        env:
+          EXEC_ARGS: >-
+            ${{ github.event.inputs.only != '' && format('--only {0}', github.event.inputs.only) || '' }}
+            --timeout-ms ${{ github.event.inputs.timeout_ms }}
+        run: mvn -B -ntp -f ../pom.xml -pl karate-js-test262 -o exec:java -Dexec.args="$EXEC_ARGS"
+
+      - name: Generate HTML report
+        working-directory: karate-js-test262
+        run: >
+          mvn -B -ntp -f ../pom.xml -pl karate-js-test262 -o exec:java
+          -Dexec.mainClass=io.karatelabs.js.test262.Test262Report
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test262-report
+          retention-days: 14
+          path: |
+            karate-js-test262/html/
+            karate-js-test262/results.jsonl
+            karate-js-test262/run-meta.json
+
+      - name: Print summary
+        if: always()
+        run: |
+          if [ -f karate-js-test262/run-meta.json ]; then
+            echo "### test262 summary" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat karate-js-test262/run-meta.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/JS_ENGINE.md
+++ b/docs/JS_ENGINE.md
@@ -2,7 +2,7 @@
 
 This document describes the JavaScript engine architecture, type system, and Java interop patterns for karate-js.
 
-> See also: [DESIGN.md](./DESIGN.md) | [TODOS.md](./TODOS.md) | [karate-js README](../karate-js/README.md)
+> See also: [DESIGN.md](./DESIGN.md) | [TODOS.md](./TODOS.md) | [karate-js README](../karate-js/README.md) | [karate-js-test262 README](../karate-js-test262/README.md)
 
 ---
 

--- a/karate-js-test262/.gitignore
+++ b/karate-js-test262/.gitignore
@@ -1,0 +1,9 @@
+# Anchored to the module root — without the leading slash these patterns
+# would also match the "io/karatelabs/js/test262" package directory and the
+# "src/test/" tree, swallowing our own source files.
+/test262/
+/html/
+/results.jsonl
+/run-meta.json
+/logs/
+/target/

--- a/karate-js-test262/README.md
+++ b/karate-js-test262/README.md
@@ -1,0 +1,562 @@
+# karate-js-test262
+
+ECMAScript [test262](https://github.com/tc39/test262) conformance harness for
+karate-js.
+
+This module is the **living document** for evolving karate-js toward spec
+compliance: a reproducible pass/fail matrix across the whole ES surface area,
+plus the roadmap for which tiers to tackle in which order. It is **not**
+published to Maven Central — it is an internal testing/reporting harness.
+
+> **See also (start a fresh session here):**
+> [../karate-js/README.md](../karate-js/README.md) for what karate-js is ·
+> [../docs/JS_ENGINE.md](../docs/JS_ENGINE.md) for engine architecture
+> (types, prototype system, exception model, benchmarks) ·
+> [../docs/DESIGN.md](../docs/DESIGN.md) for the wider project design ·
+> [test262 INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)
+> for the authoritative test-runner spec.
+
+---
+
+## Quick start
+
+**All commands run from the `karate-js-test262/` directory** (the runner
+resolves `config/expectations.yaml` and `test262/` relative to the current
+working directory). If you run from the repo root, pass `--expectations`
+and `--test262` as absolute paths.
+
+```sh
+cd karate-js-test262
+./fetch-test262.sh                                # first time only — shallow clone
+mvn -f ../pom.xml -pl karate-js-test262 -am -o exec:java \
+    -Dexec.args="--only test/language/expressions/addition/**"
+mvn -f ../pom.xml -pl karate-js-test262 -o exec:java \
+    -Dexec.mainClass=io.karatelabs.js.test262.Test262Report
+open html/index.html
+```
+
+The `-f ../pom.xml` makes Maven use the parent reactor for `-pl -am`
+resolution while keeping the working directory inside the module so the
+runner finds its config. This is the one-liner convention used throughout
+this document.
+
+Typical inner loop: change something in `karate-js/`, re-run with the same
+`--only`, refresh the HTML report, drill into a failing test via its
+`Reproducer` button.
+
+---
+
+## Why this exists
+
+karate-js is a lightweight JavaScript engine. Hand-written JUnit tests in
+`karate-js/src/test/java/` cover behaviors we care about but tell us nothing
+about **spec compliance**. Running tc39/test262 gives us ground truth — and
+the module's committed skip list
+([`config/expectations.yaml`](config/expectations.yaml)) becomes the
+declarative statement of "what karate-js deliberately does not support."
+
+The **real bar** is not spec-lawyer compliance — it is *can karate-js run
+real-world JavaScript written in the wild, especially by LLMs?* test262 is
+the scorecard; pragmatic ES6 coverage of idiomatic code is the goal.
+
+Design goals:
+
+- **Observable state** — every test is PASS / FAIL / SKIP with a reason.
+- **Tight iteration** — sequential runs, silent except failures, HTML
+  drill-down with a one-liner reproducer per failing test.
+- **Declarative non-goals** — features/flags/paths we skip are listed with
+  one-line reasons, in YAML, in git.
+- **No noise** — `results.jsonl` is currently gitignored; the committed
+  expectations.yaml tells the story of intent. Revisit committing results
+  once the engine is stable enough that diffs are meaningful.
+
+---
+
+## Working principles
+
+These are operating-mode guidelines for anyone picking up engine-compliance
+work. They apply alongside the Roadmap below.
+
+1. **Real-world JS is the target, test262 is the scorecard.** When you're
+   triaging failures, weight "does this break common LLM-written code?"
+   higher than "does this break an obscure spec corner?" A fix that
+   unblocks 500 idiomatic tests is worth more than one that tightens a
+   rarely-exercised edge case. The tier list already reflects this
+   ordering (fundamentals → common built-ins → long tail).
+
+2. **Fix friction before moving on.** If the harness makes something hard
+   to see, or the engine makes something hard to debug, **stop and fix it
+   first**. Concretely:
+   - Bad error messages in `results.jsonl` → improve `ErrorUtils` or the
+     engine's error-framing, don't work around it.
+   - Can't tell parse-phase from runtime-phase → improve the classifier
+     or the engine's exception typing.
+   - HTML report missing something you keep wanting → add it to
+     `Test262Report`.
+   - `--single -vv` doesn't show what you need → extend it; use the
+     event listener hook.
+   Working around tooling pain compounds over 50k tests; fixing it once
+   pays back the same day.
+
+3. **The engine event system is fair game for testability.** karate-js's
+   `ContextListener` / `Event` / `BindEvent` surface (see
+   [JS_ENGINE.md](../docs/JS_ENGINE.md)) exists partly for debugging and
+   introspection. If exposing a new event or adding a field to an existing
+   one makes test262 failures dramatically clearer, do it — this is not
+   a load-bearing API guarantee.
+
+4. **Performance is a feature.** The suite runs a fresh `new Engine()` per
+   test (~50k tests); regressions of a few µs in engine startup or
+   per-statement eval cost compound into minutes of wall time. After any
+   non-trivial engine change, run
+   [`EngineBenchmark`](../karate-js/src/test/java/io/karatelabs/parser/EngineBenchmark.java)
+   and compare against the reference results in
+   [JS_ENGINE.md § Performance Benchmarks](../docs/JS_ENGINE.md#performance-benchmarks).
+   See the [check performance](#check-performance-after-an-engine-change)
+   recipe below.
+
+5. **Small, focused engine changes.** Prefer several small PRs over one
+   sweeping one. The test262 scorecard makes it easy to attribute
+   regressions when changes are tight.
+
+---
+
+## Directory layout
+
+```
+karate-js-test262/
+├── README.md                         # this file (the living document)
+├── pom.xml                           # Maven module (deploy explicitly disabled)
+├── fetch-test262.sh                  # shallow clone of tc39/test262 at pinned SHA
+├── config/
+│   └── expectations.yaml             # declarative SKIP list (committed)
+├── src/main/java/…/test262/          # runner + report + helpers
+├── src/test/java/…/test262/          # unit tests for the harness itself
+├── src/main/resources/report/        # HTML/CSS/JS templates for the report
+├── test262/                          # [gitignored] the cloned suite
+├── results.jsonl                     # [gitignored] per-test pass/fail/skip
+├── run-meta.json                     # [gitignored] per-run context
+├── html/                             # [gitignored] generated report
+└── logs/                             # [gitignored] --single verbose output
+```
+
+---
+
+## Running the suite
+
+All commands assume `cwd = karate-js-test262/` (see Quick Start). Use
+`-f ../pom.xml` so Maven finds the parent reactor.
+
+```sh
+# Full suite (sequential; minutes to tens of minutes)
+mvn -f ../pom.xml -pl karate-js-test262 -am -o exec:java
+
+# Narrow to a tier (see Roadmap below)
+mvn -f ../pom.xml -pl karate-js-test262 -o exec:java \
+    -Dexec.args="--only test/language/expressions/**"
+
+# Debug one test end-to-end (prints metadata, source, classification)
+mvn -f ../pom.xml -pl karate-js-test262 -o exec:java \
+    -Dexec.args="--single test/language/expressions/addition/S11.6.1_A1.js -vv"
+
+# Resume after a crash — re-uses the existing results.jsonl
+#   (caveat: does NOT refresh records for tests that were since removed or
+#    re-classified as SKIP. Delete results.jsonl for a clean run.)
+mvn -f ../pom.xml -pl karate-js-test262 -o exec:java -Dexec.args="--resume"
+```
+
+### All flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--expectations <path>` | `config/expectations.yaml` | skip list manifest |
+| `--test262 <path>` | `test262` | suite clone dir |
+| `--results <path>` | `results.jsonl` | output JSONL |
+| `--run-meta <path>` | `run-meta.json` | output run metadata |
+| `--timeout-ms <n>` | `10000` | per-test watchdog (infinite-loop guard) |
+| `--only <glob>` | — | restrict to matching paths |
+| `--single <path>` | — | run one test, no file writes |
+| `-v` / `-vv` | off | (with `--single`) `-v` prints parsed metadata; `-vv` adds full source |
+| `--resume` | off | skip tests already in existing `results.jsonl` |
+
+Runs are **silent except failures**. A `FAIL <path> — <type>: <msg>` line is
+printed as each failure occurs; a one-line summary ends the run. Generate the
+HTML report separately with `-Dexec.mainClass=io.karatelabs.js.test262.Test262Report`.
+
+---
+
+## Results schema
+
+`results.jsonl` — one line per test, sorted alphabetically by path:
+
+```jsonl
+{"path":"test/language/expressions/addition/S11.6.1_A1.js","status":"PASS"}
+{"path":"test/.../something.js","status":"FAIL","error_type":"TypeError","message":"foo is not a function"}
+{"path":"test/.../bigint-test.js","status":"SKIP","reason":"BigInt not supported"}
+```
+
+Error types are classified into:
+`SyntaxError | TypeError | ReferenceError | RangeError | Error | Timeout |
+Harness | Unknown`
+
+by inspecting message prefixes (the engine emits `"TypeError: ..."` style
+messages at most failure sites; see
+[JS_ENGINE.md#exception-handling](../docs/JS_ENGINE.md#exception-handling)).
+The classifier itself is in `ErrorUtils`.
+
+---
+
+## The skip list
+
+There is only one concept: **SKIP**. A test matching any rule in
+`config/expectations.yaml` is not run and appears as `{"status":"SKIP",...}`
+in results. Everything else is attempted; failures are failures.
+
+Match order: `paths → flags → features → includes`. First match wins. Every
+entry requires a `reason`.
+
+**Precedence example.** A test at `test/language/statements/class/foo.js`
+with `flags: [module]` and `features: [Symbol]` is skipped with the
+*module* reason (the `flags` match fires before `features` is consulted).
+If you want `features: [Symbol]` to win, don't have a matching flag rule.
+
+See [`config/expectations.yaml`](config/expectations.yaml) for the starter
+set and rationale (Symbol, BigInt, generators, class syntax, Proxy, Reflect,
+Promises, async/await, Temporal, TypedArray beyond Uint8Array, WeakRef,
+ArrayBuffer, and the suite directories `test/intl402/`, `test/staging/`,
+`test/annexB/`).
+
+---
+
+## How this interacts with karate-js
+
+The runner relies on three small engine behaviors (see
+[JS_ENGINE.md](../docs/JS_ENGINE.md#exception-handling) for the full model):
+
+1. `io.karatelabs.parser.ParserException` propagates unchanged out of
+   `Engine.eval(...)` — used to match `phase: parse` negative tests by type.
+2. `io.karatelabs.js.EngineException` wraps everything else with the cause
+   chain preserved — the runner classifies the error by message prefix.
+3. For `throw new TypeError('x')` style tests, `Interpreter.evalProgram`
+   prefixes the message with the JS error-object name so that prefix-based
+   classification works uniformly.
+
+If you find yourself wanting a more structured error surface (e.g. typed
+`EngineException.getJsError()`), that is a valid engine improvement — the
+current prefix-based classifier is a pragmatic starting point, not a
+commitment.
+
+---
+
+## Roadmap — what to work on next
+
+**This is the living section.** Tiers are ordered for the stated goal:
+*handle real-world JS written in the wild, especially by LLMs.* That means
+**core built-ins (Object/Array/String) move up** — they're in every
+paragraph of idiomatic JS — interleaved with the grammar/scoping work that
+they depend on. Tier numbers are priority order, not a strict dependency
+DAG.
+
+For each tier, run with the given `--only` glob, triage the HTML report,
+fix in the engine, re-run. A tier is "done enough" when its non-skipped
+tests are ≥95% PASS; then graduate to the next.
+
+### Tier 0 — lexer, parser, source-text fundamentals
+
+Nothing above this is meaningful if these fail. Most are ES5 bedrock.
+
+| Area | `--only` glob |
+|---|---|
+| Whitespace & line terminators | `test/language/white-space/** test/language/line-terminators/**` |
+| Comments | `test/language/comments/**` |
+| Punctuators | `test/language/punctuators/**` |
+| Reserved words / keywords | `test/language/reserved-words/** test/language/keywords/**` |
+| Identifiers (names, Unicode escapes) | `test/language/identifiers/**` |
+| Literals (number, string, boolean, null, regexp) | `test/language/literals/**` |
+
+### Tier 1 — operators and primitive type semantics
+
+The "engine math is wrong" bucket: `typeof`, `instanceof`, `in`, `delete`,
+`new`, `void`, `comma`, plus ToNumber/ToString/ToPrimitive coercions.
+Fixes here cascade into most other tiers.
+
+| Area | `--only` glob |
+|---|---|
+| All expressions | `test/language/expressions/**` |
+| Primitive conversions | `test/language/types/**` |
+
+### Tier 2 — core built-ins that LLM-written JS leans on
+
+**Promoted ahead of statements/functions** because idiomatic modern JS is
+`arr.map(...).filter(...)`, `Object.keys(x).forEach(...)`, template
+literals, destructuring. If these don't work, neither does anything LLMs
+produce.
+
+| Order | Built-in | `--only` glob |
+|---|---|---|
+| 1 | `Object` | `test/built-ins/Object/**` |
+| 2 | `Array` | `test/built-ins/Array/**` |
+| 3 | `String` | `test/built-ins/String/**` |
+| 4 | Destructuring | `test/language/expressions/**/dstr-** test/language/statements/**/dstr-** test/language/destructuring/**` |
+| 5 | Template literals | `test/language/expressions/template-literal/**` |
+| 6 | Object literals (shorthand, computed) | `test/language/expressions/object/**` |
+| 7 | Array literals (holes, spread) | `test/language/expressions/array/**` |
+
+Destructuring is *not* blanket-skipped in `expectations.yaml` — we want
+real engine breakage surfaced here, since LLMs write `const {a, b} = obj`
+constantly.
+
+### Tier 3 — statements and control flow
+
+`if`, `for`, `while`, `do-while`, `switch`, `break`, `continue`, `return`,
+`throw`, `try/catch/finally`, `var`, `let`, `const`, labeled statements.
+
+| Area | `--only` glob |
+|---|---|
+| All statements | `test/language/statements/**` |
+
+`with` is not supported by karate-js — add to `expectations.yaml` under
+paths if needed (`test/language/statements/with/**`).
+
+### Tier 4 — functions, scoping, `this` binding
+
+| Area | `--only` glob |
+|---|---|
+| Function bodies & hoisting | `test/language/function-code/**` |
+| arguments object | `test/language/arguments-object/**` |
+| Block scope (let/const TDZ) | `test/language/block-scope/**` |
+| Function expressions | `test/language/expressions/function/**` |
+| Arrow functions | `test/language/expressions/arrow-function/**` |
+| Call / new semantics | `test/language/expressions/call/** test/language/expressions/new/**` |
+| Property accessors | `test/language/expressions/property-accessors/**` |
+
+### Tier 5 — remaining built-ins
+
+Less-frequently-used but still needed for full ES6 coverage.
+
+| Order | Built-in | `--only` glob |
+|---|---|---|
+| 1 | `Number` | `test/built-ins/Number/**` |
+| 2 | `Math` | `test/built-ins/Math/**` |
+| 3 | `JSON` | `test/built-ins/JSON/**` |
+| 4 | `Error` (and subtypes) | `test/built-ins/Error/** test/built-ins/TypeError/** test/built-ins/RangeError/** test/built-ins/ReferenceError/**` |
+| 5 | `Function` | `test/built-ins/Function/**` |
+| 6 | `RegExp` | `test/built-ins/RegExp/**` |
+| 7 | `Date` | `test/built-ins/Date/**` |
+| 8 | `Boolean` | `test/built-ins/Boolean/**` |
+
+### Tier 6 — long tail
+
+`directive-prologue/`, `eval-code/`, `global-code/`, iterators (mostly
+already skipped via `Symbol.iterator`), regex edge features on the skip
+list. Revisit when earlier tiers are green.
+
+---
+
+## Known first-order gaps
+
+High-leverage issues that each break many tests at once. Fixing one of these
+is worth more than fixing twenty one-off bugs. Grow this list as tiers run;
+remove items once fixed.
+
+- **Missing global error constructors.** `ReferenceError`, `RangeError`,
+  `URIError`, `EvalError` (and `SyntaxError` as a runtime-catchable
+  constructor) are not registered as globals — only `Error` and `TypeError`
+  are. Any test that does `throw new RangeError(...)` or
+  `assert.throws(ReferenceError, ...)` fails with
+  `"RangeError is not defined"`. Registering these (pointing at the
+  existing `JsError` machinery with the right `name`) unlocks a large
+  fraction of the test262 tree.
+- **Comma / sequence operator not accepted inside parentheses.** `(a, b)`,
+  `(0, eval)(x)`, `for (i = 0, j = 0; ...; i++, j++)`, and all patterns
+  that put a sequence expression in parens fail to parse with
+  `expected: [R_PAREN]`. This blocks the idiomatic `(0, eval)(src)`
+  indirect-eval trick that test262's `$262.evalScript` is supposed to use,
+  plus many in-the-wild patterns. The runner currently works around it
+  with `var indirect = eval; indirect(src)`, but this is exactly the
+  friction the engine should fix per working principle #2. Spec: this is
+  the `Expression : Expression , AssignmentExpression` production, ES1.
+  **Design note for the fix session:** the parser already has an
+  `expr_list()` helper in `JsParser.java` (handles comma-separated
+  expressions for other contexts); consider whether that can be reused
+  or adapted rather than introducing a new `SEQ_EXPR` node type —
+  worth thinking through before picking an approach. Affected call sites
+  (where comma is spec-legal): `paren_expr`, `if_stmt`/`while_stmt`/
+  `do_while_stmt`/`switch_stmt` conditions, `return_stmt`, `throw_stmt`,
+  all three `for_stmt` slots, top-level expression statements.
+- **Harness-helper dependencies we currently skip.** `propertyHelper.js`,
+  `compareArray.js`, `testTypedArray.js`, etc. depend on engine internals
+  karate-js does not expose (descriptor introspection via
+  `Object.getOwnPropertyDescriptor`, proper iterator protocol, etc.).
+  These gate **thousands** of `test/built-ins/**` tests currently SKIP'd
+  via `expectations.yaml`. Once Tier 2's built-ins work, un-skipping these
+  helpers one at a time is the next lever.
+- **Engine framing noise in error messages.** The default `EngineException`
+  wraps runtime errors in a multi-line `js failed: / ========== / Code: /
+  Error: ...` frame. The runner strips this in `ErrorUtils.unwrapFraming`,
+  but JS-side fixtures that inspect `.message` via `assert.throws` may see
+  the framed text. Consider reserving the frame for logging and exposing
+  the raw message via `EngineException.getMessage()`.
+- *(more will land here as tiers are worked; remove items once fixed.)*
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| `expectations file not found: config/expectations.yaml` | You ran from the wrong directory. `cd karate-js-test262` first (see Quick Start). |
+| `test262 directory not found: test262` | You haven't run `./fetch-test262.sh` yet (or you're in the wrong dir). |
+| HTML dashboard shows empty header | `run-meta.json` missing — run `Test262Report` *after* `Test262Runner` in the same directory. |
+| `ReferenceError: <name> is not defined` on common classes like `ReferenceError`/`RangeError` | Known first-order gap — those constructors are not registered globals yet. |
+| Suite seems to hang on one test | Infinite loop; watchdog should kick in at `--timeout-ms`. If it doesn't, bisect with `--only`. |
+| Tests that used to pass now fail after an engine change | Run `EngineBenchmark` too — perf regression sometimes manifests as timeouts before correctness. |
+| `--resume` gives stale results | Known limitation — it doesn't refresh records for tests that were removed or re-SKIP'd. Delete `results.jsonl` for a clean baseline. |
+
+---
+
+## Deferred TODOs
+
+Items left for later; un-scheduled but tracked.
+
+- **Replace hand-rolled YAML parser with SnakeYAML.** `Expectations.java`
+  and `Test262Metadata.java` are hand-rolled to avoid the dep. They break
+  on `#` in quoted reasons, block-scalar (`|`, `>`) `description:` fields,
+  and block-form list values. Add SnakeYAML when we next touch either
+  file; one dep is fine.
+- **Make `--resume` refresh stale records.** Currently echoes back records
+  for tests that no longer exist or are now SKIP'd. Either gate on
+  test-still-exists + not-in-skip-list, or rename to `--resume-crash-only`.
+- **Cache parsed harness ASTs, not source text.** `HarnessLoader` currently
+  re-parses `assert.js`, `sta.js`, and each test's `includes:` on every
+  test; ~50k re-parses per full-suite run is a measurable chunk of wall
+  time. Cache `Node` trees and re-eval from AST.
+- **Parallel test execution.** Runner is sequential. Each test gets a
+  fresh `Engine`, so per-test isolation holds; switch
+  `ExecutorService` to a thread pool once the classifier is stable enough
+  that non-deterministic ordering in logs is acceptable.
+- **`phase: resolution` (module-resolution) negative tests.** Currently
+  conflated with `runtime`. Modules are globally skipped via
+  `flags: [module]`, so this is latent — document if we ever un-skip
+  modules.
+- **Structured `$262` surface.** `AbstractModuleSource`, `IsHTMLDDA`,
+  `agent.broadcast/getReport/sleep/monotonicNow` are absent — all are
+  feature-gated in tests, so they're unreachable today. Add stubs when a
+  feature is moved off the skip list.
+- **`readHeadSha` path fragility.** `Test262Runner.readHeadSha` walks up
+  `cli.test262.getParent().getParent()` to find the karate repo. Prefer a
+  `git rev-parse HEAD` subprocess, or a `--karate-sha` flag.
+- **Thread-safe `HarnessLoader` cache.** `HashMap` is fine for
+  sequential runs; switch to `ConcurrentHashMap` before enabling parallel
+  execution.
+- **Commit `results.jsonl` once stable.** Currently gitignored (too noisy
+  in git while engine iterates). Re-evaluate when Tier 0–2 are ≥95%
+  green — at that point, diff-based regression detection becomes the
+  cheapest signal.
+
+---
+
+## Recipes
+
+### Add a skip rule
+
+Edit `config/expectations.yaml`, add under the right section, always with a
+`reason`:
+
+```yaml
+skip:
+  features:
+    - feature: Temporal
+      reason: Temporal proposal not implemented
+```
+
+Match order is `paths → flags → features → includes`; first match wins.
+
+### Remove a skip rule (feature is now supported)
+
+Delete the entry. Re-run the relevant tier's `--only` glob. Tests that were
+skipped will now run; if they pass, you're done. If they fail, use
+`--single <path> -vv` to debug and fix before removing the skip.
+
+### Debug one failing test
+
+Find its `--only` link in the HTML report's FAIL list, then:
+
+```sh
+mvn -pl karate-js-test262 -o exec:java \
+    -Dexec.args="--single <path> -vv"
+```
+
+The `-vv` output includes the parsed YAML metadata, the resolved harness
+helpers, the classification, and the full test source. The HTML
+drill-down page has the same reproducer command pre-filled.
+
+### Promote from one tier to the next
+
+When a tier's `--only` run is ≥95% PASS of its non-skipped tests, commit
+whatever engine fixes you made, update the Roadmap's "Known first-order
+gaps" if anything new emerged, and move on to the next tier. No ceremony.
+
+### Check performance after an engine change
+
+The conformance suite allocates a fresh `Engine` per test (~50k tests in
+the default pinned SHA); small regressions compound into minutes of wall
+time. After any non-trivial engine change:
+
+```sh
+# Fast (median of 10 runs) — noisy but quick feedback
+mvn -pl karate-js -q test-compile
+java -cp "karate-js/target/classes:karate-js/target/test-classes:$(find ~/.m2/repository -name 'slf4j-api-*.jar' | head -1):$(find ~/.m2/repository -name 'json-smart-*.jar' | head -1):$(find ~/.m2/repository -name 'accessors-smart-*.jar' | head -1):$(find ~/.m2/repository -name 'asm-9*.jar' | grep -v asm-tree | grep -v asm-commons | head -1)" \
+    io.karatelabs.parser.EngineBenchmark
+
+# Profile mode (30 s warm loop; JIT-stable, much lower noise)
+java -cp "…same classpath…" io.karatelabs.parser.EngineBenchmark profile
+```
+
+Compare against the reference numbers in
+[JS_ENGINE.md § Performance Benchmarks](../docs/JS_ENGINE.md#performance-benchmarks).
+If the medians moved materially (>±10% in profile mode), understand why
+before merging. If the change is unavoidable (correctness > speed), update
+the reference table in `JS_ENGINE.md` in the same commit.
+
+### Fix harness friction
+
+If you hit friction while iterating — unreadable error messages in results,
+missing info in `--single -vv`, a gap in HTML drill-down — **fix that first**,
+don't work around it. The engine's `ContextListener` event surface can be
+extended for testability; bad error framing in `EngineException` can be
+improved. See Working Principle #2 above.
+
+### Bump the pinned test262 SHA
+
+Edit the `TEST262_SHA=...` line at the top of `fetch-test262.sh`, delete
+the local `test262/` directory, re-run the script. All subsequent runs use
+the new commit. Coordinate bumps with whoever else is iterating — the test
+suite itself evolves and can add/remove tests.
+
+---
+
+## CI
+
+A `workflow_dispatch`-only workflow at
+[`.github/workflows/test262.yml`](../.github/workflows/test262.yml) runs
+`fetch-test262.sh` + the runner + the report, and uploads both the HTML
+tree and `results.jsonl` as artifacts. It is never triggered automatically
+— you kick it off from the Actions tab when you want a fresh run.
+
+The module's `pom.xml` sets `maven.deploy.skip=true` / `gpg.skip=true` /
+`skipPublishing=true` so the release workflow
+([`.github/workflows/maven-release.yml`](../.github/workflows/maven-release.yml))
+does not publish this module to Maven Central.
+
+---
+
+## References
+
+- [tc39/test262](https://github.com/tc39/test262) — the suite
+- [test262 INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)
+  — authoritative runner spec
+- [../docs/JS_ENGINE.md](../docs/JS_ENGINE.md) — karate-js engine architecture,
+  type system, exception model, and benchmarks
+- [../karate-js/README.md](../karate-js/README.md) — what karate-js is and isn't
+- [../docs/DESIGN.md](../docs/DESIGN.md) — wider project design principles

--- a/karate-js-test262/config/expectations.yaml
+++ b/karate-js-test262/config/expectations.yaml
@@ -1,0 +1,151 @@
+# test262 expectations for karate-js
+#
+# Only concept: SKIP. If a test matches any rule below, it's not run
+# and appears in results.jsonl as {"status":"SKIP","reason":...}.
+# Everything else is attempted — failures are failures, recorded as FAIL.
+#
+# Match order: paths -> flags -> features -> includes. First match wins.
+# All entries MUST have a `reason` (one short sentence).
+#
+# To add a skip: put the rule in the right section, write the reason, commit.
+
+version: 1
+
+skip:
+
+  # Entire suite directories that are out of scope for an ES6 core engine.
+  # Paths use glob syntax (* matches within a segment, ** across segments).
+  paths:
+    - path: test/intl402/**
+      reason: internationalization (ECMA-402) out of scope
+    - path: test/staging/**
+      reason: experimental proposals not yet ratified
+    - path: test/annexB/**
+      reason: legacy-web-browser behaviors out of scope
+
+  # Tests whose YAML frontmatter contains any of these `flags:` values.
+  flags:
+    - flag: module
+      reason: karate-js does not support ES modules
+    - flag: async
+      reason: async/await not supported
+    - flag: onlyStrict
+      reason: strict-mode-only tests not applicable (engine has no separate strict mode)
+    - flag: CanBlockIsTrue
+      reason: engine cannot block on shared-memory worker agents
+    - flag: CanBlockIsFalse
+      reason: CanBlock flag not modeled
+
+  # Tests whose YAML frontmatter contains any of these `features:` values.
+  features:
+    - feature: Symbol
+      reason: Symbol not supported
+    - feature: Symbol.asyncIterator
+      reason: Symbol not supported
+    - feature: Symbol.iterator
+      reason: Symbol not supported
+    - feature: BigInt
+      reason: BigInt not supported
+    - feature: generators
+      reason: generator functions not supported
+    - feature: class
+      reason: class syntax not supported (use prototypes)
+    - feature: class-fields-public
+      reason: class syntax not supported
+    - feature: class-fields-private
+      reason: class syntax not supported
+    - feature: class-methods-private
+      reason: class syntax not supported
+    - feature: class-static-fields-public
+      reason: class syntax not supported
+    - feature: class-static-methods-private
+      reason: class syntax not supported
+    - feature: Proxy
+      reason: Proxy not implemented
+    - feature: Reflect
+      reason: Reflect not implemented
+    - feature: async-functions
+      reason: async/await not supported
+    - feature: async-iteration
+      reason: async/await not supported
+    - feature: Temporal
+      reason: Temporal proposal not implemented
+    - feature: TypedArray
+      reason: only Uint8Array is supported
+    - feature: ArrayBuffer
+      reason: ArrayBuffer semantics not implemented
+    - feature: SharedArrayBuffer
+      reason: SharedArrayBuffer not implemented
+    - feature: DataView
+      reason: DataView not implemented
+    - feature: Atomics
+      reason: Atomics not supported
+    - feature: WeakRef
+      reason: WeakRef not implemented
+    - feature: FinalizationRegistry
+      reason: FinalizationRegistry not implemented
+    - feature: WeakMap
+      reason: WeakMap not implemented
+    - feature: WeakSet
+      reason: WeakSet not implemented
+    - feature: Promise
+      reason: Promises not supported
+    - feature: Promise.any
+      reason: Promises not supported
+    - feature: Promise.allSettled
+      reason: Promises not supported
+    - feature: regexp-named-groups
+      reason: named regex groups not yet implemented
+    - feature: regexp-lookbehind
+      reason: regex lookbehind not yet implemented
+    - feature: regexp-unicode-property-escapes
+      reason: unicode property escapes not implemented
+    - feature: regexp-match-indices
+      reason: match indices not implemented
+    - feature: regexp-duplicate-named-groups
+      reason: duplicate named groups not implemented
+    - feature: regexp-v-flag
+      reason: /v regex flag not implemented
+    - feature: dynamic-import
+      reason: dynamic import not supported
+    - feature: optional-chaining
+      reason: optional chaining operator not implemented
+    - feature: nullish-coalescing
+      reason: nullish coalescing not implemented
+    - feature: numeric-separator-literal
+      reason: numeric separators not implemented
+    - feature: tail-call-optimization
+      reason: tail-call optimization not guaranteed
+    # destructuring-binding is INTENTIONALLY NOT skipped — LLM-written JS uses
+    # `const { a, b } = obj` constantly; we want to surface real breakage here.
+    # If engine support proves too incomplete, re-add with a specific reason.
+    - feature: new.target
+      reason: new.target not supported
+    - feature: Array.prototype.includes
+      reason: not implemented
+    - feature: globalThis
+      reason: globalThis not exposed
+
+  # Tests whose YAML frontmatter `includes:` references any of these harness helpers
+  # (the harness file itself may exist, but it depends on engine internals we do not expose).
+  includes:
+    - include: propertyHelper.js
+      reason: requires engine internals karate-js does not expose
+    - include: nativeFunctionMatcher.js
+      reason: depends on Function.prototype.toString internals
+    - include: promiseHelper.js
+      reason: Promises not supported
+    - include: detachArrayBuffer.js
+      reason: ArrayBuffer semantics not implemented
+    - include: compareArray.js
+      reason: depends on Symbol.iterator
+    - include: testTypedArray.js
+      reason: TypedArray (beyond Uint8Array) not supported
+    - include: testAtomics.js
+      reason: Atomics not supported
+    - include: testBigIntTypedArray.js
+      reason: BigInt not supported
+    - include: testIntl.js
+      reason: internationalization out of scope
+    - include: proxyTrapsHelper.js
+      reason: Proxy not implemented

--- a/karate-js-test262/fetch-test262.sh
+++ b/karate-js-test262/fetch-test262.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Fetches the tc39/test262 suite at a pinned SHA. Idempotent.
+#
+# Re-run to update: edit TEST262_SHA below, then run this script.
+# The checkout is shallow (single commit, blobless) so the clone stays small.
+
+set -euo pipefail
+
+# Pinned test262 commit (edit to bump). Use a full 40-char SHA.
+TEST262_SHA="d5e73fc8d2c663554fb72e2380a8c2bc1a318a33"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DIR="$HERE/test262"
+
+if [ ! -d "$DIR/.git" ]; then
+    echo "cloning tc39/test262 into $DIR ..."
+    git clone --filter=blob:none --no-checkout https://github.com/tc39/test262.git "$DIR"
+fi
+
+cd "$DIR"
+
+# Fetch just the one commit we want.
+git fetch --depth 1 origin "$TEST262_SHA"
+git checkout --force "$TEST262_SHA"
+
+echo ""
+echo "test262 checked out at:"
+echo "  $DIR"
+echo "  SHA: $TEST262_SHA"
+echo ""
+echo "Suite sizes:"
+find test -type f -name '*.js' 2>/dev/null | awk -F/ '
+    { top = $2; count[top]++; total++ }
+    END {
+        for (t in count) printf "  %-16s %6d\n", t, count[t]
+        printf "  %-16s %6d\n", "TOTAL", total
+    }
+' | sort

--- a/karate-js-test262/pom.xml
+++ b/karate-js-test262/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.karatelabs</groupId>
+        <artifactId>karate-parent</artifactId>
+        <version>2.0.5.RC1</version>
+    </parent>
+
+    <artifactId>karate-js-test262</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <description>ECMAScript test262 conformance harness for karate-js</description>
+
+    <!--
+      This module is an internal testing/reporting harness. It must NOT be
+      published to Maven Central when running the release workflow (see
+      .github/workflows/maven-release.yml).
+    -->
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>false</maven.install.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <gpg.skip>true</gpg.skip>
+        <skipPublishing>true</skipPublishing>
+    </properties>
+
+    <build>
+        <plugins>
+            <!-- Belt-and-braces: explicitly skip the source-attach execution
+                 inherited from the parent pom for this internal module. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <mainClass>io.karatelabs.js.test262.Test262Runner</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.karatelabs</groupId>
+            <artifactId>karate-js</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/Cli.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/Cli.java
@@ -1,0 +1,91 @@
+package io.karatelabs.js.test262;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tiny hand-rolled flag parser for the runner. Keeps things predictable and
+ * avoids pulling in a CLI library for a handful of flags.
+ */
+public final class Cli {
+
+    public Path expectations = Paths.get("config/expectations.yaml");
+    public Path test262 = Paths.get("test262");
+    public Path results = Paths.get("results.jsonl");
+    public Path runMeta = Paths.get("run-meta.json");
+    public long timeoutMs = 10_000L;
+    public String only;         // glob; null = no restriction
+    public String single;       // relative path to one test262 file; null = full suite
+    public int verbose;         // 0, 1, 2
+    public boolean resume;
+    public final List<String> rawArgs = new ArrayList<>();
+
+    public static Cli parse(String[] args) {
+        Cli c = new Cli();
+        for (int i = 0; i < args.length; i++) {
+            String a = args[i];
+            c.rawArgs.add(a);
+            if (needsValue(a)) {
+                String v = args[++i];
+                c.rawArgs.add(v);
+                switch (a) {
+                    case "--expectations" -> c.expectations = Paths.get(v);
+                    case "--test262"      -> c.test262 = Paths.get(v);
+                    case "--results"      -> c.results = Paths.get(v);
+                    case "--run-meta"     -> c.runMeta = Paths.get(v);
+                    case "--timeout-ms"   -> c.timeoutMs = Long.parseLong(v);
+                    case "--only"         -> c.only = v;
+                    case "--single"       -> c.single = v;
+                    default -> { /* unreachable: needsValue gates this */ }
+                }
+                continue;
+            }
+            switch (a) {
+                case "--resume"     -> c.resume = true;
+                case "-v"           -> c.verbose = Math.max(c.verbose, 1);
+                case "-vv"          -> c.verbose = 2;
+                case "-h", "--help" -> { printHelp(); System.exit(0); }
+                default -> {
+                    if (a.startsWith("-")) {
+                        System.err.println("unknown flag: " + a);
+                        printHelp();
+                        System.exit(2);
+                    }
+                }
+            }
+        }
+        return c;
+    }
+
+    private static boolean needsValue(String flag) {
+        return switch (flag) {
+            case "--expectations", "--test262", "--results", "--run-meta",
+                 "--timeout-ms", "--only", "--single" -> true;
+            default -> false;
+        };
+    }
+
+    public static void printHelp() {
+        System.out.println("""
+            karate-js-test262 runner
+
+            Usage: java io.karatelabs.js.test262.Test262Runner [flags]
+
+            Flags:
+              --expectations <path>   YAML skip list (default: config/expectations.yaml)
+              --test262 <path>        test262 clone root (default: test262)
+              --results <path>        output JSONL path (default: results.jsonl)
+              --run-meta <path>       output metadata JSON (default: run-meta.json)
+              --timeout-ms <n>        per-test watchdog (default: 10000)
+              --only <glob>           restrict to tests matching a path glob, e.g. 'test/language/**'
+              --single <path>         run exactly one test (no file writes); use -vv to trace
+              -v | -vv                verbose output (--single mode only)
+              --resume                skip tests already present in the existing results.jsonl
+              -h | --help             show this help
+
+            Prerequisite: ./fetch-test262.sh (one-time)
+            """);
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/ErrorUtils.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/ErrorUtils.java
@@ -1,0 +1,101 @@
+package io.karatelabs.js.test262;
+
+import io.karatelabs.js.EngineException;
+
+/**
+ * Classifies a thrown exception into a test262-style error type name.
+ * <p>
+ * Prefers the structured {@link EngineException#getJsErrorName()} surface
+ * (set when an uncaught JS {@code throw} propagates out of the engine). Falls
+ * back to message-prefix scanning for engine-origin errors that use the
+ * {@code "TypeError: ..."} / {@code "RangeError: ..."} convention (see
+ * {@code JavaUtils.java}, {@code Prototype.java}, {@code JsNumberPrototype.java}).
+ * <p>
+ * Returns one of:
+ * {@code "SyntaxError" | "TypeError" | "ReferenceError" | "RangeError" | "URIError" | "EvalError" | "Error"}
+ * — or {@code null} if nothing recognizable is found.
+ */
+public final class ErrorUtils {
+
+    private ErrorUtils() {}
+
+    private static final String[] KNOWN_NAMES = {
+            "SyntaxError", "TypeError", "ReferenceError",
+            "RangeError", "URIError", "EvalError", "Error"
+    };
+
+    /** @return canonical error type name, or {@code null} if unrecognized. */
+    public static String classify(Throwable t) {
+        // Walk the cause chain for any EngineException carrying a structured JS error name.
+        Throwable cur = t;
+        while (cur != null) {
+            if (cur instanceof EngineException ee && ee.getJsErrorName() != null) {
+                return canonicalize(ee.getJsErrorName());
+            }
+            Throwable next = cur.getCause();
+            if (next == cur) break;
+            cur = next;
+        }
+        // Fallback: message-prefix scan (catches engine-origin "TypeError: ..." etc.).
+        cur = t;
+        while (cur != null) {
+            String name = classifyByMessagePrefix(cur.getMessage());
+            if (name != null) return name;
+            Throwable next = cur.getCause();
+            if (next == cur) break;
+            cur = next;
+        }
+        return null;
+    }
+
+    /** Scans {@code text} for a recognizable {@code "<Name>: "} prefix. */
+    private static String classifyByMessagePrefix(String text) {
+        if (text == null) return null;
+        // After unwrapping any engine "js failed: ... Error: <body>" framing, look at the body.
+        String body = unwrapFraming(text);
+        for (String name : KNOWN_NAMES) {
+            if (body.startsWith(name + ":") || body.startsWith(name + " ")) {
+                return name;
+            }
+        }
+        // Heuristic for engine-emitted ReferenceError messages ("foo is not defined").
+        if (body.contains("is not defined")) return "ReferenceError";
+        return null;
+    }
+
+    /** Accepts variants like "typeerror" and returns canonical form, else input unchanged. */
+    private static String canonicalize(String name) {
+        for (String k : KNOWN_NAMES) {
+            if (k.equalsIgnoreCase(name)) return k;
+        }
+        return name;
+    }
+
+    /**
+     * Extracts the first informative line of a message, trimmed to {@code maxLen}.
+     * Strips the {@code "js failed: / ==========" } framing so JSONL messages show
+     * the actual error body.
+     */
+    public static String firstLine(String message, int maxLen) {
+        if (message == null) return null;
+        String body = unwrapFraming(message);
+        int nl = body.indexOf('\n');
+        String line = nl < 0 ? body : body.substring(0, nl);
+        line = line.strip();
+        if (line.length() > maxLen) line = line.substring(0, maxLen - 1) + "…";
+        return line;
+    }
+
+    /**
+     * Strips karate-js's standard {@code "js failed: / ========== / ... / Error: <body>"}
+     * framing to return just the error body. Unchanged if no framing is detected.
+     */
+    private static String unwrapFraming(String message) {
+        int errIdx = message.indexOf("  Error:");
+        if (errIdx < 0) return message;
+        String after = message.substring(errIdx + "  Error:".length()).stripLeading();
+        int closer = after.indexOf("\n==========");
+        if (closer >= 0) after = after.substring(0, closer);
+        return after;
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/Expectations.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/Expectations.java
@@ -1,0 +1,218 @@
+package io.karatelabs.js.test262;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Loads {@code config/expectations.yaml} and matches a {@link Test262Case}
+ * against its skip rules.
+ * <p>
+ * Match order: paths -> flags -> features -> includes. First match wins and
+ * produces the SKIP reason. See the YAML file itself for the full schema.
+ * <p>
+ * This is a tiny custom parser scoped to the fixed schema this module uses.
+ * We avoid the SnakeYAML dependency.
+ */
+public final class Expectations {
+
+    private final List<SkipRule> paths;
+    private final Map<String, String> flags;     // flag -> reason
+    private final Map<String, String> features;  // feature -> reason
+    private final Map<String, String> includes;  // include -> reason
+
+    private Expectations(List<SkipRule> paths, Map<String, String> flags,
+                         Map<String, String> features, Map<String, String> includes) {
+        this.paths = paths;
+        this.flags = flags;
+        this.features = features;
+        this.includes = includes;
+    }
+
+    public static Expectations load(Path yamlFile) {
+        try {
+            String text = Files.readString(yamlFile);
+            return parse(text);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to read expectations: " + yamlFile, e);
+        }
+    }
+
+    /**
+     * @return the SKIP reason if the case should be skipped, or {@code null} to run it.
+     */
+    public String matchSkip(Test262Case c) {
+        String rel = c.relativePath();
+        for (SkipRule p : paths) {
+            if (p.matches(rel)) return p.reason;
+        }
+        Test262Metadata m = c.metadata();
+        for (String f : m.flags()) {
+            String reason = flags.get(f);
+            if (reason != null) return reason;
+        }
+        for (String f : m.features()) {
+            String reason = features.get(f);
+            if (reason != null) return reason;
+        }
+        for (String inc : m.includes()) {
+            String reason = includes.get(inc);
+            if (reason != null) return reason;
+        }
+        return null;
+    }
+
+    /* -------------------------------- parsing -------------------------------- */
+
+    private static Expectations parse(String yaml) {
+        List<SkipRule> paths = new ArrayList<>();
+        Map<String, String> flags = new LinkedHashMap<>();
+        Map<String, String> features = new LinkedHashMap<>();
+        Map<String, String> includes = new LinkedHashMap<>();
+
+        // State machine for a very restricted YAML subset. We parse only what the
+        // bundled expectations.yaml uses: a top-level "skip:" block containing
+        // 4 nested lists (paths, flags, features, includes), each list item a
+        // 2-field object (key + reason).
+        String[] lines = yaml.split("\n", -1);
+        String currentSection = null;          // "paths" | "flags" | "features" | "includes"
+        String pendingKey = null;
+        String pendingReason = null;
+        String pendingField = null;            // field name that "key" resolves to (path/flag/feature/include)
+        int i = 0;
+        while (i < lines.length) {
+            String raw = stripComment(lines[i]);
+            i++;
+            String stripped = raw.strip();
+            if (stripped.isEmpty()) continue;
+
+            int indent = raw.length() - raw.stripLeading().length();
+
+            if (indent == 0) {
+                if (stripped.endsWith(":")) {
+                    // could be "version:" or "skip:" — ignore top-level scalars we don't use
+                }
+                continue;
+            }
+            if (indent == 2 && stripped.endsWith(":")) {
+                String section = stripped.substring(0, stripped.length() - 1);
+                switch (section) {
+                    case "paths":    currentSection = "paths";    pendingField = "path";    break;
+                    case "flags":    currentSection = "flags";    pendingField = "flag";    break;
+                    case "features": currentSection = "features"; pendingField = "feature"; break;
+                    case "includes": currentSection = "includes"; pendingField = "include"; break;
+                    default:         currentSection = null;       pendingField = null;      break;
+                }
+                continue;
+            }
+            if (currentSection == null) continue;
+
+            // List items at indent 4 start with "- key: value"; continuation at indent 6 carries "reason: ..."
+            if (stripped.startsWith("- ")) {
+                flush(currentSection, pendingKey, pendingReason, paths, flags, features, includes);
+                pendingKey = null;
+                pendingReason = null;
+                String rest = stripped.substring(2);
+                // rest like "path: test/foo/**"
+                int colon = rest.indexOf(':');
+                if (colon < 0) continue;
+                String k = rest.substring(0, colon).strip();
+                String v = unquote(rest.substring(colon + 1).strip());
+                if (k.equals(pendingField)) {
+                    pendingKey = v;
+                }
+            } else {
+                int colon = stripped.indexOf(':');
+                if (colon < 0) continue;
+                String k = stripped.substring(0, colon).strip();
+                String v = unquote(stripped.substring(colon + 1).strip());
+                if (k.equals("reason")) {
+                    pendingReason = v;
+                } else if (k.equals(pendingField)) {
+                    // list item with mixed order (reason first, key second)
+                    pendingKey = v;
+                }
+            }
+        }
+        flush(currentSection, pendingKey, pendingReason, paths, flags, features, includes);
+
+        return new Expectations(paths, flags, features, includes);
+    }
+
+    private static void flush(String section, String key, String reason,
+                              List<SkipRule> paths,
+                              Map<String, String> flags,
+                              Map<String, String> features,
+                              Map<String, String> includes) {
+        if (section == null || key == null) return;
+        String r = reason == null ? "(no reason)" : reason;
+        switch (section) {
+            case "paths"    -> paths.add(new SkipRule(key, r));
+            case "flags"    -> flags.put(key, r);
+            case "features" -> features.put(key, r);
+            case "includes" -> includes.put(key, r);
+            default -> { /* ignore */ }
+        }
+    }
+
+    private static String stripComment(String s) {
+        // simple: "#" outside a quoted string begins a comment
+        int hash = s.indexOf('#');
+        if (hash < 0) return s;
+        // Only strip if the # is not part of a quoted value.
+        // For our constrained schema (no quoted values with #), plain split is fine.
+        return s.substring(0, hash);
+    }
+
+    private static String unquote(String s) {
+        if (s.length() >= 2 && s.startsWith("\"") && s.endsWith("\"")) {
+            return s.substring(1, s.length() - 1);
+        }
+        if (s.length() >= 2 && s.startsWith("'") && s.endsWith("'")) {
+            return s.substring(1, s.length() - 1);
+        }
+        return s;
+    }
+
+    /* -------------------------- path glob matching -------------------------- */
+
+    /** A path skip rule, compiled from a glob pattern like {@code test/intl402/**}. */
+    private record SkipRule(String pattern, String reason) {
+        private static final Map<String, Pattern> CACHE = new java.util.concurrent.ConcurrentHashMap<>();
+
+        boolean matches(String path) {
+            Pattern p = CACHE.computeIfAbsent(pattern, SkipRule::globToRegex);
+            return p.matcher(path).matches();
+        }
+
+        private static Pattern globToRegex(String glob) {
+            StringBuilder sb = new StringBuilder("^");
+            int i = 0;
+            while (i < glob.length()) {
+                char c = glob.charAt(i);
+                if (c == '*') {
+                    if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                        sb.append(".*");
+                        i += 2;
+                        if (i < glob.length() && glob.charAt(i) == '/') i++;
+                        continue;
+                    }
+                    sb.append("[^/]*");
+                } else if (c == '?') {
+                    sb.append('.');
+                } else if ("\\.^$+()[]{}|".indexOf(c) >= 0) {
+                    sb.append('\\').append(c);
+                } else {
+                    sb.append(c);
+                }
+                i++;
+            }
+            sb.append('$');
+            return Pattern.compile(sb.toString());
+        }
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/HarnessLoader.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/HarnessLoader.java
@@ -1,0 +1,54 @@
+package io.karatelabs.js.test262;
+
+import io.karatelabs.js.Engine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads test262 harness helpers (assert.js, sta.js, plus the per-test {@code includes}).
+ * <p>
+ * Harness files are read from {@code <test262>/harness/} and cached in memory since
+ * the same ~40 helpers are loaded over and over across the suite.
+ */
+public final class HarnessLoader {
+
+    private final Path harnessDir;
+    private final Map<String, String> cache = new HashMap<>();
+
+    public HarnessLoader(Path test262Root) {
+        this.harnessDir = test262Root.resolve("harness");
+    }
+
+    /** Always-loaded helpers mandated by test262 (see CONTRIBUTING.md). */
+    public static final List<String> DEFAULT_HELPERS = List.of("assert.js", "sta.js");
+
+    /** Loads default helpers plus the test's declared {@code includes}, in that order. */
+    public void primeEngine(Engine engine, List<String> testIncludes) {
+        for (String h : DEFAULT_HELPERS) {
+            evalHelper(engine, h);
+        }
+        for (String h : testIncludes) {
+            if (DEFAULT_HELPERS.contains(h)) continue; // already loaded
+            evalHelper(engine, h);
+        }
+    }
+
+    private void evalHelper(Engine engine, String name) {
+        String src = cache.computeIfAbsent(name, this::readHelper);
+        engine.eval(src);
+    }
+
+    private String readHelper(String name) {
+        Path p = harnessDir.resolve(name);
+        try {
+            return Files.readString(p);
+        } catch (IOException e) {
+            throw new RuntimeException("missing harness helper: " + p, e);
+        }
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/JsonLite.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/JsonLite.java
@@ -1,0 +1,97 @@
+package io.karatelabs.js.test262;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal JSON writing + reading for the small fixed schemas this module uses
+ * (JSONL records, run-meta, embedded summary). Avoids pulling a JSON library
+ * into the module.
+ */
+final class JsonLite {
+
+    private JsonLite() {}
+
+    static void writeString(StringBuilder sb, String s) {
+        if (s == null) { sb.append("null"); return; }
+        sb.append('"');
+        for (int i = 0, n = s.length(); i < n; i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"'  -> sb.append("\\\"");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        sb.append('"');
+    }
+
+    /** Serializes a Map or List of simple scalars into pretty JSON (2-space indent). */
+    static String writePretty(Object value) {
+        StringBuilder sb = new StringBuilder(256);
+        writePrettyInto(sb, value, 0);
+        sb.append('\n');
+        return sb.toString();
+    }
+
+    private static void writePrettyInto(StringBuilder sb, Object value, int indent) {
+        if (value == null) {
+            sb.append("null");
+            return;
+        }
+        if (value instanceof String s) {
+            writeString(sb, s);
+            return;
+        }
+        if (value instanceof Number || value instanceof Boolean) {
+            sb.append(value);
+            return;
+        }
+        if (value instanceof Map<?, ?> m) {
+            if (m.isEmpty()) { sb.append("{}"); return; }
+            sb.append("{\n");
+            int i = 0, last = m.size() - 1;
+            for (Map.Entry<?, ?> e : m.entrySet()) {
+                pad(sb, indent + 1);
+                writeString(sb, e.getKey().toString());
+                sb.append(": ");
+                writePrettyInto(sb, e.getValue(), indent + 1);
+                if (i++ < last) sb.append(',');
+                sb.append('\n');
+            }
+            pad(sb, indent);
+            sb.append('}');
+            return;
+        }
+        if (value instanceof List<?> list) {
+            if (list.isEmpty()) { sb.append("[]"); return; }
+            sb.append("[\n");
+            int i = 0, last = list.size() - 1;
+            for (Object o : list) {
+                pad(sb, indent + 1);
+                writePrettyInto(sb, o, indent + 1);
+                if (i++ < last) sb.append(',');
+                sb.append('\n');
+            }
+            pad(sb, indent);
+            sb.append(']');
+            return;
+        }
+        writeString(sb, value.toString());
+    }
+
+    private static void pad(StringBuilder sb, int indent) {
+        for (int i = 0; i < indent; i++) sb.append("  ");
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/ResultRecord.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/ResultRecord.java
@@ -1,0 +1,49 @@
+package io.karatelabs.js.test262;
+
+/**
+ * One row in results.jsonl. Immutable. The runner writes these sorted by {@code path}.
+ * <p>
+ * JSON key order is fixed (path, status, error_type, message, reason) so that
+ * file diffs across runs are minimal and interpretable. All optional fields are
+ * omitted when null.
+ */
+public record ResultRecord(
+        String path,
+        Status status,
+        String errorType,
+        String message,
+        String reason) {
+
+    public enum Status { PASS, FAIL, SKIP }
+
+    public static ResultRecord pass(String path) {
+        return new ResultRecord(path, Status.PASS, null, null, null);
+    }
+
+    public static ResultRecord fail(String path, String errorType, String message) {
+        return new ResultRecord(path, Status.FAIL, errorType, message, null);
+    }
+
+    public static ResultRecord skip(String path, String reason) {
+        return new ResultRecord(path, Status.SKIP, null, null, reason);
+    }
+
+    /** Writes this record as a single JSONL line (no trailing newline). */
+    public String toJsonLine() {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append('{');
+        appendKv(sb, "path", path, true);
+        appendKv(sb, "status", status.name(), false);
+        if (errorType != null) appendKv(sb, "error_type", errorType, false);
+        if (message != null) appendKv(sb, "message", message, false);
+        if (reason != null) appendKv(sb, "reason", reason, false);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static void appendKv(StringBuilder sb, String key, String value, boolean first) {
+        if (!first) sb.append(',');
+        sb.append('"').append(key).append("\":");
+        JsonLite.writeString(sb, value);
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/ResultWriter.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/ResultWriter.java
@@ -1,0 +1,35 @@
+package io.karatelabs.js.test262;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Atomic JSONL writer: sorts records alphabetically by path and writes with
+ * a .tmp + rename so a crash mid-write can't corrupt the committed file.
+ */
+public final class ResultWriter {
+
+    private ResultWriter() {}
+
+    public static void write(Path file, List<ResultRecord> records) throws IOException {
+        List<ResultRecord> sorted = new java.util.ArrayList<>(records);
+        Collections.sort(sorted, Comparator.comparing(ResultRecord::path));
+
+        StringBuilder sb = new StringBuilder(sorted.size() * 64);
+        for (ResultRecord r : sorted) {
+            sb.append(r.toJsonLine()).append('\n');
+        }
+
+        Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
+        Path parent = tmp.getParent();
+        if (parent != null) Files.createDirectories(parent);
+        Files.writeString(tmp, sb.toString(), StandardCharsets.UTF_8);
+        Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/RunMeta.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/RunMeta.java
@@ -1,0 +1,61 @@
+package io.karatelabs.js.test262;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Gitignored per-run context. Captured at the end of a full run and used
+ * by the HTML report to render a self-describing header.
+ */
+public record RunMeta(
+        String test262Sha,
+        String karateJsVersion,
+        String karateJsGitSha,
+        String jdk,
+        String os,
+        Instant startedAt,
+        Instant endedAt,
+        Counts counts,
+        List<String> cliArgs) {
+
+    public record Counts(int pass, int fail, int skip, int total) {}
+
+    public void writeTo(Path file) throws IOException {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("test262_sha", test262Sha == null ? "" : test262Sha);
+        m.put("karate_js_version", karateJsVersion == null ? "" : karateJsVersion);
+        m.put("karate_js_git_sha", karateJsGitSha == null ? "" : karateJsGitSha);
+        m.put("jdk", jdk);
+        m.put("os", os);
+        m.put("started_at", startedAt.toString());
+        m.put("ended_at", endedAt.toString());
+        m.put("elapsed_ms", Duration.between(startedAt, endedAt).toMillis());
+        Map<String, Object> c = new LinkedHashMap<>();
+        c.put("pass", counts.pass());
+        c.put("fail", counts.fail());
+        c.put("skip", counts.skip());
+        c.put("total", counts.total());
+        m.put("counts", c);
+        m.put("cli_args", cliArgs);
+
+        Path parent = file.getParent();
+        if (parent != null) Files.createDirectories(parent);
+        Files.writeString(file, JsonLite.writePretty(m), StandardCharsets.UTF_8);
+    }
+
+    public static String detectJdk() {
+        return System.getProperty("java.vm.name", "?") + " " + System.getProperty("java.version", "?");
+    }
+
+    public static String detectOs() {
+        return System.getProperty("os.name", "?") + " " + System.getProperty("os.version", "?")
+                + " (" + System.getProperty("os.arch", "?") + ")";
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Case.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Case.java
@@ -1,0 +1,32 @@
+package io.karatelabs.js.test262;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A single test262 test file, with its source text and parsed frontmatter.
+ *
+ * @param relativePath  path relative to the test262 root (e.g. "test/language/...js")
+ * @param absolutePath  absolute path on disk
+ * @param source        full file contents (UTF-8)
+ * @param metadata      parsed YAML frontmatter (empty if not present)
+ */
+public record Test262Case(
+        String relativePath,
+        Path absolutePath,
+        String source,
+        Test262Metadata metadata) {
+
+    public static Test262Case load(Path test262Root, Path absolute) {
+        try {
+            String src = Files.readString(absolute);
+            Test262Metadata meta = Test262Metadata.parse(src);
+            String rel = test262Root.relativize(absolute).toString();
+            // Normalize Windows separators to forward slashes for stable paths in results.
+            rel = rel.replace('\\', '/');
+            return new Test262Case(rel, absolute, src, meta);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to load test262 case: " + absolute, e);
+        }
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Metadata.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Metadata.java
@@ -1,0 +1,119 @@
+package io.karatelabs.js.test262;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parsed YAML frontmatter of a test262 test file. Only the fields the runner
+ * actually consults are kept. See the test262 CONTRIBUTING.md for the full schema.
+ */
+public record Test262Metadata(
+        List<String> flags,
+        List<String> features,
+        List<String> includes,
+        Negative negative,
+        boolean raw,
+        String description) {
+
+    /** If non-null, the test is expected to fail at the given phase with the given constructor. */
+    public record Negative(String phase, String type) {}
+
+    /**
+     * Parses the {@code /*--- ... ---*\/} block at the top of a test262 file.
+     * Returns a metadata with empty lists and null negative if no frontmatter present.
+     * <p>
+     * This is a tolerant line-based reader, not a full YAML parser. test262 uses
+     * a constrained subset (inline arrays for flags/features/includes, a nested
+     * "negative:" block). We cover exactly that subset.
+     */
+    public static Test262Metadata parse(String source) {
+        int start = source.indexOf("/*---");
+        if (start < 0) return empty();
+        int end = source.indexOf("---*/", start);
+        if (end < 0) return empty();
+        String body = source.substring(start + 5, end);
+
+        List<String> flags = new ArrayList<>();
+        List<String> features = new ArrayList<>();
+        List<String> includes = new ArrayList<>();
+        String negPhase = null;
+        String negType = null;
+        boolean inNegative = false;
+        boolean raw = false;
+        String description = null;
+
+        for (String line : body.split("\n")) {
+            String stripped = line.strip();
+            if (stripped.isEmpty()) continue;
+
+            // Top-level key starts at column 0 of the original line (after the "---" opener).
+            // We use a simple heuristic: a line whose first non-space char is a letter, that
+            // also contains ":" before whitespace, is a key. Nested keys are indented.
+            int indent = line.length() - line.stripLeading().length();
+
+            if (inNegative) {
+                if (indent == 0) {
+                    inNegative = false;
+                    // fall through to top-level handling
+                } else {
+                    if (stripped.startsWith("phase:")) {
+                        negPhase = after(stripped, "phase:").strip();
+                    } else if (stripped.startsWith("type:")) {
+                        negType = after(stripped, "type:").strip();
+                    }
+                    continue;
+                }
+            }
+
+            if (stripped.startsWith("flags:")) {
+                flags.addAll(parseInlineArray(after(stripped, "flags:")));
+                if (flags.contains("raw")) raw = true;
+            } else if (stripped.startsWith("features:")) {
+                features.addAll(parseInlineArray(after(stripped, "features:")));
+            } else if (stripped.startsWith("includes:")) {
+                includes.addAll(parseInlineArray(after(stripped, "includes:")));
+            } else if (stripped.startsWith("negative:")) {
+                inNegative = true;
+            } else if (stripped.startsWith("description:")) {
+                description = after(stripped, "description:").strip();
+            }
+        }
+
+        return new Test262Metadata(
+                Collections.unmodifiableList(flags),
+                Collections.unmodifiableList(features),
+                Collections.unmodifiableList(includes),
+                (negPhase == null && negType == null) ? null : new Negative(negPhase, negType),
+                raw,
+                description);
+    }
+
+    public static Test262Metadata empty() {
+        return new Test262Metadata(List.of(), List.of(), List.of(), null, false, null);
+    }
+
+    private static String after(String line, String key) {
+        return line.substring(line.indexOf(key) + key.length());
+    }
+
+    /** Parses an inline YAML array like {@code "[foo, bar baz, qux]"} or {@code "[]"}. */
+    static List<String> parseInlineArray(String s) {
+        String t = s.strip();
+        if (t.isEmpty()) return List.of();
+        if (t.startsWith("[")) {
+            int close = t.lastIndexOf(']');
+            if (close < 0) return List.of();
+            String inner = t.substring(1, close);
+            if (inner.isBlank()) return List.of();
+            List<String> out = new ArrayList<>();
+            for (String part : inner.split(",")) {
+                String p = part.strip();
+                if (!p.isEmpty()) out.add(p);
+            }
+            return out;
+        }
+        // Not an inline array — could be a block-style list (rare in test262 for these keys).
+        return List.of();
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Report.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Report.java
@@ -1,0 +1,358 @@
+package io.karatelabs.js.test262;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Reads {@code results.jsonl} + {@code run-meta.json} and writes a static
+ * HTML dashboard under {@code html/}. Fully static; no server, no runtime JSON
+ * fetches. The dashboard page and per-failure drill-downs are self-contained.
+ * <p>
+ * Usage:
+ * <pre>
+ *   java io.karatelabs.js.test262.Test262Report \
+ *       [--results results.jsonl] [--run-meta run-meta.json] \
+ *       [--test262 test262] [--out html]
+ * </pre>
+ */
+public final class Test262Report {
+
+    public static void main(String[] args) throws Exception {
+        Path results = Paths.get("results.jsonl");
+        Path runMeta = Paths.get("run-meta.json");
+        Path test262Dir = Paths.get("test262");
+        Path outDir = Paths.get("html");
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--results"   -> results = Paths.get(args[++i]);
+                case "--run-meta"  -> runMeta = Paths.get(args[++i]);
+                case "--test262"   -> test262Dir = Paths.get(args[++i]);
+                case "--out"       -> outDir = Paths.get(args[++i]);
+                case "-h", "--help" -> {
+                    System.out.println("Usage: Test262Report [--results <p>] [--run-meta <p>] [--test262 <p>] [--out <dir>]");
+                    return;
+                }
+                default -> { /* ignore */ }
+            }
+        }
+
+        if (!Files.isRegularFile(results)) {
+            System.err.println("results file not found: " + results.toAbsolutePath());
+            System.err.println("run Test262Runner first");
+            System.exit(2);
+        }
+
+        List<Row> rows = readResults(results);
+        String metaJson = Files.isRegularFile(runMeta) ? Files.readString(runMeta) : "{}";
+
+        Files.createDirectories(outDir);
+        Files.createDirectories(outDir.resolve("fail"));
+
+        copyResource("/report/styles.css", outDir.resolve("styles.css"));
+        copyResource("/report/app.js", outDir.resolve("app.js"));
+
+        writeIndex(outDir.resolve("index.html"), rows, metaJson);
+
+        int failCount = 0;
+        for (Row r : rows) {
+            if ("FAIL".equals(r.status)) {
+                failCount++;
+                writeFailPage(outDir.resolve("fail").resolve(sanitizePath(r.path) + ".html"),
+                        r, test262Dir);
+            }
+        }
+
+        System.out.println("Wrote report to: " + outDir.toAbsolutePath());
+        System.out.println("  " + rows.size() + " total rows");
+        System.out.println("  " + failCount + " per-test FAIL pages");
+    }
+
+    /* ------------------------------- model ------------------------------- */
+
+    record Row(String path, String status, String errorType, String message, String reason) {}
+
+    private static List<Row> readResults(Path jsonl) throws IOException {
+        List<Row> out = new ArrayList<>();
+        try (BufferedReader br = Files.newBufferedReader(jsonl, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.isBlank()) continue;
+                String path = between(line, "\"path\":\"", "\"");
+                String status = between(line, "\"status\":\"", "\"");
+                String errorType = between(line, "\"error_type\":\"", "\"");
+                String message = between(line, "\"message\":\"", "\"");
+                String reason = between(line, "\"reason\":\"", "\"");
+                if (path != null && status != null) out.add(new Row(path, status, errorType, message, reason));
+            }
+        }
+        // Already alphabetical in the file, but sort defensively.
+        out.sort(Comparator.comparing(Row::path));
+        return out;
+    }
+
+    /* ------------------------------ index.html ------------------------------ */
+
+    private static void writeIndex(Path file, List<Row> rows, String metaJson) throws IOException {
+        int pass = 0, fail = 0, skip = 0;
+        // Top-level dir stats: test/<X>/...
+        Map<String, int[]> topStats = new TreeMap<>();
+        // Nested tree for drill-down
+        DirNode root = new DirNode("test");
+
+        for (Row r : rows) {
+            switch (r.status) {
+                case "PASS" -> pass++;
+                case "FAIL" -> fail++;
+                case "SKIP" -> skip++;
+            }
+            String[] parts = r.path.split("/");
+            if (parts.length >= 2) {
+                int[] s = topStats.computeIfAbsent(parts[1], k -> new int[3]);
+                switch (r.status) { case "PASS" -> s[0]++; case "FAIL" -> s[1]++; case "SKIP" -> s[2]++; }
+                if ("test".equals(parts[0])) {
+                    addToTree(root, parts, 1, r);
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("""
+            <!doctype html>
+            <html lang="en">
+            <head>
+            <meta charset="utf-8">
+            <title>karate-js · test262 results</title>
+            <link rel="stylesheet" href="styles.css">
+            </head>
+            <body>
+            <header>
+              <h1>karate-js &middot; test262</h1>
+              <div id="meta"></div>
+              <div class="summary">
+            """);
+        sb.append(String.format(
+                "    <span class=\"pill pass\">%d pass</span>\n" +
+                "    <span class=\"pill fail\">%d fail</span>\n" +
+                "    <span class=\"pill skip\">%d skip</span>\n" +
+                "    <span class=\"pill total\">%d total</span>\n",
+                pass, fail, skip, pass + fail + skip));
+        sb.append("  </div>\n");
+        sb.append("  <div class=\"filters\">\n");
+        sb.append("    <input id=\"q\" placeholder=\"filter by path substring…\" />\n");
+        sb.append("    <label><input type=\"checkbox\" class=\"status-filter\" data-s=\"PASS\" checked> PASS</label>\n");
+        sb.append("    <label><input type=\"checkbox\" class=\"status-filter\" data-s=\"FAIL\" checked> FAIL</label>\n");
+        sb.append("    <label><input type=\"checkbox\" class=\"status-filter\" data-s=\"SKIP\" checked> SKIP</label>\n");
+        sb.append("  </div>\n");
+        sb.append("</header>\n");
+
+        sb.append("<h2>By top-level suite</h2>\n<ul class=\"top-stats\">\n");
+        for (Map.Entry<String, int[]> e : topStats.entrySet()) {
+            int[] s = e.getValue();
+            sb.append(String.format(
+                    "  <li><strong>%s</strong> <span class=\"bar\">%s</span> <span class=\"counts\">%d / %d / %d</span></li>%n",
+                    escape(e.getKey()), barSvg(s[0], s[1], s[2]), s[0], s[1], s[2]));
+        }
+        sb.append("</ul>\n");
+
+        sb.append("<h2>Tree</h2>\n<div id=\"tree\">\n");
+        renderTree(sb, root, 0);
+        sb.append("</div>\n");
+
+        // Embed run-meta as a JSON island. HTML entities are NOT decoded inside
+        // <script type="application/json">, so we must NOT html-escape here.
+        // We only need to neutralize the byte sequence "</" (which would end the script
+        // element) by splitting it with a Unicode escape that JSON.parse tolerates.
+        sb.append("<script id=\"run-meta\" type=\"application/json\">")
+          .append(metaJson.replace("</", "<\\/"))
+          .append("</script>\n");
+        sb.append("<script src=\"app.js\"></script>\n");
+        sb.append("</body></html>\n");
+
+        Files.writeString(file, sb.toString(), StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private static String barSvg(int pass, int fail, int skip) {
+        int total = pass + fail + skip;
+        if (total == 0) return "";
+        int pw = (int) Math.round(100.0 * pass / total);
+        int fw = (int) Math.round(100.0 * fail / total);
+        int sw = 100 - pw - fw;
+        return "<svg width=\"100\" height=\"10\" viewBox=\"0 0 100 10\">" +
+                "<rect x=\"0\" width=\"" + pw + "\" height=\"10\" fill=\"#4caf50\"/>" +
+                "<rect x=\"" + pw + "\" width=\"" + fw + "\" height=\"10\" fill=\"#e53935\"/>" +
+                "<rect x=\"" + (pw + fw) + "\" width=\"" + sw + "\" height=\"10\" fill=\"#9e9e9e\"/>" +
+                "</svg>";
+    }
+
+    /* --------------------------- per-test FAIL page --------------------------- */
+
+    private static void writeFailPage(Path outFile, Row r, Path test262Dir) throws IOException {
+        Files.createDirectories(outFile.getParent());
+        String src;
+        try {
+            src = Files.readString(test262Dir.resolve(r.path));
+        } catch (IOException e) {
+            src = "(unable to read source: " + e.getMessage() + ")";
+        }
+        String reproducer = "java io.karatelabs.js.test262.Test262Runner --single "
+                + r.path + " -vv";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<!doctype html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">\n");
+        sb.append("<title>").append(escape(r.path)).append(" — FAIL</title>\n");
+        sb.append("<link rel=\"stylesheet\" href=\"../styles.css\">\n</head><body>\n");
+        sb.append("<p><a href=\"../index.html\">&larr; back to index</a></p>\n");
+        sb.append("<h1>").append(escape(r.path)).append("</h1>\n");
+        sb.append("<div class=\"summary\"><span class=\"pill fail\">FAIL");
+        if (r.errorType != null) sb.append(" — ").append(escape(r.errorType));
+        sb.append("</span></div>\n");
+        if (r.message != null) {
+            sb.append("<h2>Error</h2>\n<pre class=\"error\">").append(escape(r.message)).append("</pre>\n");
+        }
+        sb.append("<h2>Reproducer</h2>\n<pre class=\"cmd\">").append(escape(reproducer)).append("</pre>\n");
+        sb.append("<h2>Source</h2>\n<pre class=\"source\">").append(numbered(src)).append("</pre>\n");
+        sb.append("</body></html>\n");
+        Files.writeString(outFile, sb.toString(), StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private static String numbered(String src) {
+        String[] lines = src.split("\n", -1);
+        StringBuilder sb = new StringBuilder(src.length() + lines.length * 6);
+        int width = String.valueOf(Math.max(1, lines.length)).length();
+        for (int i = 0; i < lines.length; i++) {
+            String num = String.valueOf(i + 1);
+            while (num.length() < width) num = " " + num;
+            sb.append("<span class=\"ln\">").append(num).append("</span>  ")
+              .append(escape(lines[i])).append('\n');
+        }
+        return sb.toString();
+    }
+
+    /* ------------------------------- tree ------------------------------- */
+
+    private record DirNode(String name,
+                           Map<String, DirNode> children,
+                           List<Row> tests) {
+        DirNode(String name) { this(name, new LinkedHashMap<>(), new ArrayList<>()); }
+    }
+
+    private static void addToTree(DirNode root, String[] parts, int idx, Row r) {
+        // path is "test/a/b/c.js". parts[0]="test" already at root.
+        DirNode cur = root;
+        for (int i = idx; i < parts.length - 1; i++) {
+            String seg = parts[i];
+            cur = cur.children.computeIfAbsent(seg, DirNode::new);
+        }
+        cur.tests.add(r);
+    }
+
+    private static void renderTree(StringBuilder sb, DirNode node, int depth) {
+        int[] counts = totals(node);
+        int pass = counts[0], fail = counts[1], skip = counts[2];
+        String summary = "<span class=\"bar\">" + barSvg(pass, fail, skip) + "</span>"
+                + " <span class=\"counts\">" + pass + " / " + fail + " / " + skip + "</span>";
+        sb.append("<details").append(depth == 0 ? " open" : "").append(">\n");
+        sb.append("<summary><span class=\"dir\">").append(escape(node.name)).append("</span> ").append(summary).append("</summary>\n");
+
+        List<String> sortedChildren = new ArrayList<>(node.children.keySet());
+        Collections.sort(sortedChildren);
+        for (String c : sortedChildren) renderTree(sb, node.children.get(c), depth + 1);
+
+        List<Row> tests = new ArrayList<>(node.tests);
+        tests.sort(Comparator.comparing(Row::path));
+        if (!tests.isEmpty()) {
+            sb.append("<ul class=\"tests\">\n");
+            for (Row r : tests) {
+                sb.append("  <li class=\"t t-").append(r.status).append("\" data-path=\"").append(escape(r.path)).append("\">");
+                sb.append("<span class=\"status\">").append(r.status).append("</span> ");
+                if ("FAIL".equals(r.status)) {
+                    sb.append("<a href=\"fail/").append(escape(sanitizePath(r.path))).append(".html\">");
+                    sb.append(escape(basename(r.path)));
+                    sb.append("</a>");
+                    if (r.errorType != null) sb.append(" <em>").append(escape(r.errorType)).append("</em>");
+                } else {
+                    sb.append(escape(basename(r.path)));
+                    if ("SKIP".equals(r.status) && r.reason != null) {
+                        sb.append(" <em>").append(escape(r.reason)).append("</em>");
+                    }
+                }
+                sb.append("</li>\n");
+            }
+            sb.append("</ul>\n");
+        }
+        sb.append("</details>\n");
+    }
+
+    private static int[] totals(DirNode n) {
+        int p = 0, f = 0, s = 0;
+        for (Row r : n.tests) {
+            switch (r.status) { case "PASS" -> p++; case "FAIL" -> f++; case "SKIP" -> s++; }
+        }
+        for (DirNode c : n.children.values()) {
+            int[] sub = totals(c);
+            p += sub[0]; f += sub[1]; s += sub[2];
+        }
+        return new int[] { p, f, s };
+    }
+
+    /* ------------------------------- util ------------------------------- */
+
+    private static String between(String line, String left, String right) {
+        int i = line.indexOf(left);
+        if (i < 0) return null;
+        int s = i + left.length();
+        int e = line.indexOf(right, s);
+        return e < 0 ? null : line.substring(s, e);
+    }
+
+    private static String basename(String path) {
+        int i = path.lastIndexOf('/');
+        return i < 0 ? path : path.substring(i + 1);
+    }
+
+    private static String sanitizePath(String p) {
+        return p.replace('/', '_').replace('\\', '_');
+    }
+
+    private static String escape(String s) {
+        if (s == null) return "";
+        StringBuilder out = new StringBuilder(s.length());
+        for (int i = 0, n = s.length(); i < n; i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&' -> out.append("&amp;");
+                case '<' -> out.append("&lt;");
+                case '>' -> out.append("&gt;");
+                case '"' -> out.append("&quot;");
+                default -> out.append(c);
+            }
+        }
+        return out.toString();
+    }
+
+    private static void copyResource(String resource, Path dest) throws IOException {
+        try (java.io.InputStream in = Test262Report.class.getResourceAsStream(resource)) {
+            if (in == null) {
+                // Write a minimal default if the resource is missing (shouldn't happen in normal builds).
+                Files.writeString(dest, "/* missing resource: " + resource + " */\n", StandardCharsets.UTF_8);
+                return;
+            }
+            Files.copy(in, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Runner.java
+++ b/karate-js-test262/src/main/java/io/karatelabs/js/test262/Test262Runner.java
@@ -1,0 +1,448 @@
+package io.karatelabs.js.test262;
+
+import io.karatelabs.js.Engine;
+import io.karatelabs.parser.ParserException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * test262 conformance runner for karate-js.
+ * <p>
+ * Sequential, fresh {@link Engine} per test, per-test watchdog timeout.
+ * Writes results as sorted JSONL to {@code results.jsonl} (committable) and
+ * per-run context to {@code run-meta.json} (gitignored).
+ * <p>
+ * See {@code karate-js-test262/README.md} for full docs.
+ */
+public final class Test262Runner {
+
+    public static void main(String[] args) throws Exception {
+        Cli cli = Cli.parse(args);
+
+        if (!Files.isDirectory(cli.test262)) {
+            System.err.println("test262 directory not found: " + cli.test262.toAbsolutePath());
+            System.err.println("Run ./fetch-test262.sh (from the karate-js-test262 module directory) first.");
+            System.exit(2);
+        }
+        if (!Files.isRegularFile(cli.expectations)) {
+            System.err.println("expectations file not found: " + cli.expectations.toAbsolutePath());
+            System.exit(2);
+        }
+
+        Expectations expectations = Expectations.load(cli.expectations);
+        HarnessLoader harness = new HarnessLoader(cli.test262);
+
+        if (cli.single != null) {
+            runSingle(cli, expectations, harness);
+            return;
+        }
+
+        runSuite(cli, expectations, harness);
+    }
+
+    /* ------------------------------- full suite ------------------------------- */
+
+    private static void runSuite(Cli cli, Expectations expectations, HarnessLoader harness) throws Exception {
+        Path testRoot = cli.test262.resolve("test");
+        if (!Files.isDirectory(testRoot)) {
+            System.err.println("test262 'test/' directory not found: " + testRoot);
+            System.exit(2);
+        }
+
+        List<Path> all;
+        try (Stream<Path> stream = Files.walk(testRoot)) {
+            all = stream
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".js"))
+                    .filter(p -> !p.getFileName().toString().endsWith("_FIXTURE.js"))
+                    .sorted()
+                    .toList();
+        }
+
+        Pattern onlyRe = cli.only == null ? null : globToRegex(cli.only);
+        Set<String> resumeDone = cli.resume ? loadExistingPaths(cli.results) : Set.of();
+
+        Instant started = Instant.now();
+        int pass = 0, fail = 0, skip = 0;
+        List<ResultRecord> records = new ArrayList<>(all.size());
+
+        // reuse one single-thread executor across all tests for watchdog timeouts
+        ExecutorService exec = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "test262-runner");
+            t.setDaemon(true);
+            return t;
+        });
+
+        try {
+            for (Path abs : all) {
+                String rel = cli.test262.relativize(abs).toString().replace('\\', '/');
+                if (onlyRe != null && !onlyRe.matcher(rel).matches()) continue;
+                if (resumeDone.contains(rel)) continue;
+
+                Test262Case tc;
+                try {
+                    tc = Test262Case.load(cli.test262, abs);
+                } catch (RuntimeException re) {
+                    System.out.println("FAIL " + rel + " — load error: " + re.getMessage());
+                    records.add(ResultRecord.fail(rel, "Harness", "failed to load: " + re.getMessage()));
+                    fail++;
+                    continue;
+                }
+
+                String reason = expectations.matchSkip(tc);
+                if (reason != null) {
+                    records.add(ResultRecord.skip(rel, reason));
+                    skip++;
+                    continue;
+                }
+
+                ResultRecord r = runOne(tc, harness, exec, cli.timeoutMs);
+                records.add(r);
+                switch (r.status()) {
+                    case PASS -> pass++;
+                    case FAIL -> {
+                        fail++;
+                        System.out.println("FAIL " + rel + " — " + (r.errorType() == null ? "" : r.errorType() + ": ")
+                                + (r.message() == null ? "" : r.message()));
+                    }
+                    case SKIP -> skip++;
+                }
+            }
+        } finally {
+            exec.shutdownNow();
+        }
+
+        Instant ended = Instant.now();
+
+        // Re-read existing records if --resume so the committed JSONL still has everything.
+        List<ResultRecord> toWrite = records;
+        if (cli.resume && !resumeDone.isEmpty()) {
+            final List<ResultRecord> finalRecords = records;
+            List<ResultRecord> combined = new ArrayList<>(records);
+            combined.addAll(loadExistingRecords(cli.results, rel -> !containsPath(finalRecords, rel)));
+            toWrite = combined;
+        }
+
+        ResultWriter.write(cli.results, toWrite);
+
+        RunMeta meta = new RunMeta(
+                readTest262Sha(cli.test262),
+                System.getProperty("karate.js.version", ""),
+                readHeadSha(cli.test262.getParent() == null ? Path.of(".") : cli.test262.getParent().getParent()),
+                RunMeta.detectJdk(),
+                RunMeta.detectOs(),
+                started, ended,
+                new RunMeta.Counts(pass, fail, skip, pass + fail + skip),
+                cli.rawArgs);
+        meta.writeTo(cli.runMeta);
+
+        System.out.println();
+        System.out.printf("Summary: %d pass / %d fail / %d skip / %d total in %s%n",
+                pass, fail, skip, pass + fail + skip, formatDuration(java.time.Duration.between(started, ended)));
+        System.out.println("Results: " + cli.results.toAbsolutePath());
+        System.out.println("Report:  java io.karatelabs.js.test262.Test262Report");
+    }
+
+    /* ------------------------------ single-file ------------------------------ */
+
+    private static void runSingle(Cli cli, Expectations expectations, HarnessLoader harness) throws Exception {
+        Path abs = cli.test262.resolve(cli.single);
+        if (!Files.isRegularFile(abs)) {
+            System.err.println("test262 file not found: " + abs);
+            System.exit(2);
+        }
+        Test262Case tc = Test262Case.load(cli.test262, abs);
+        System.out.println("path:        " + tc.relativePath());
+        if (cli.verbose >= 1) {
+            System.out.println("description: " + (tc.metadata().description() == null ? "" : tc.metadata().description()));
+            System.out.println("flags:       " + tc.metadata().flags());
+            System.out.println("features:    " + tc.metadata().features());
+            System.out.println("includes:    " + tc.metadata().includes());
+            System.out.println("negative:    " + tc.metadata().negative());
+        }
+        String reason = expectations.matchSkip(tc);
+        if (reason != null) {
+            System.out.println("status:      SKIP — " + reason);
+            return;
+        }
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            ResultRecord r = runOne(tc, harness, exec, cli.timeoutMs);
+            System.out.println("status:      " + r.status()
+                    + (r.errorType() == null ? "" : " [" + r.errorType() + "]"));
+            if (r.message() != null) System.out.println("message:     " + r.message());
+            if (cli.verbose >= 2) {
+                System.out.println();
+                System.out.println("--- source ---");
+                System.out.println(tc.source());
+            }
+        } finally {
+            exec.shutdownNow();
+        }
+    }
+
+    /* --------------------------- per-test execution --------------------------- */
+
+    private static ResultRecord runOne(Test262Case tc, HarnessLoader harness, ExecutorService exec, long timeoutMs) {
+        Future<ResultRecord> fut = exec.submit(() -> evaluate(tc, harness));
+        try {
+            return fut.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException te) {
+            fut.cancel(true);
+            return ResultRecord.fail(tc.relativePath(), "Timeout",
+                    "no completion within " + timeoutMs + "ms");
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            return ResultRecord.fail(tc.relativePath(), "Interrupted", ie.getMessage());
+        } catch (ExecutionException ee) {
+            Throwable cause = ee.getCause() == null ? ee : ee.getCause();
+            return ResultRecord.fail(tc.relativePath(), "Unknown",
+                    ErrorUtils.firstLine(cause.getMessage(), 200));
+        }
+    }
+
+    private static ResultRecord evaluate(Test262Case tc, HarnessLoader harness) {
+        String path = tc.relativePath();
+        Test262Metadata.Negative neg = tc.metadata().negative();
+        boolean isRaw = tc.metadata().raw();
+
+        Engine engine = new Engine();
+
+        // INTERPRETING.md: raw tests must run in a pristine realm — no harness files,
+        // no host-defined bindings. Non-raw tests get host bindings THEN harness helpers,
+        // so that `sta.js` (which defines its own $DONOTEVALUATE) overrides any of ours.
+        if (!isRaw) {
+            try {
+                engine.eval(HOST_BINDINGS_JS);
+            } catch (RuntimeException e) {
+                return ResultRecord.fail(path, "Harness",
+                        "host bindings setup failed: " + ErrorUtils.firstLine(e.getMessage(), 200));
+            }
+            try {
+                harness.primeEngine(engine, tc.metadata().includes());
+            } catch (RuntimeException e) {
+                return ResultRecord.fail(path, "Harness",
+                        "harness load failed: " + ErrorUtils.firstLine(e.getMessage(), 200));
+            }
+        }
+
+        // Evaluate the test source. Parse errors surface as ParserException (phase=parse);
+        // anything else is phase=runtime.
+        try {
+            engine.eval(tc.source());
+        } catch (ParserException pe) {
+            return classifyNegative(path, neg, "parse", "SyntaxError", pe);
+        } catch (RuntimeException re) {
+            String type = ErrorUtils.classify(re);
+            String msg = ErrorUtils.firstLine(re.getMessage(), 200);
+            if (neg != null) {
+                if (!"parse".equals(neg.phase())
+                        && (neg.type() == null || neg.type().equals(type) || type == null)) {
+                    return ResultRecord.pass(path);
+                }
+                return ResultRecord.fail(path, type == null ? "Unknown" : type,
+                        "expected negative " + neg + " but got: " + msg);
+            }
+            return ResultRecord.fail(path, type == null ? "Unknown" : type, msg);
+        }
+
+        // eval succeeded
+        if (neg != null) {
+            return ResultRecord.fail(path, "ExpectedThrow",
+                    "expected negative " + neg + " but test completed normally");
+        }
+        return ResultRecord.pass(path);
+    }
+
+    private static ResultRecord classifyNegative(String path, Test262Metadata.Negative neg,
+                                                 String actualPhase, String actualType, RuntimeException re) {
+        String msg = ErrorUtils.firstLine(re.getMessage(), 200);
+        if (neg != null && actualPhase.equals(neg.phase())
+                && (neg.type() == null || neg.type().equals(actualType))) {
+            return ResultRecord.pass(path);
+        }
+        if (neg == null) {
+            return ResultRecord.fail(path, actualType, msg);
+        }
+        return ResultRecord.fail(path, actualType,
+                "expected negative " + neg + " but got " + actualPhase + "/" + actualType + ": " + msg);
+    }
+
+    /* ------------------------------- host bindings ------------------------------- */
+
+    /**
+     * Minimal host-defined bindings required by test262 INTERPRETING.md.
+     * Installed before harness helpers and before the test source (non-raw tests only).
+     * <p>
+     * - {@code print(...args)} — communication sink. Writes to stdout.
+     * - {@code $262.global} — best-effort reference to the global scope.
+     * - {@code $262.evalScript(src)} — evaluates in the global realm via indirect eval.
+     * - {@code $262.gc()} — no capability; throws (INTERPRETING.md permits this).
+     * <p>
+     * {@code $DONOTEVALUATE} is intentionally not defined here — {@code sta.js}
+     * defines it and sta.js is loaded for every non-raw test. Raw tests that
+     * use {@code $DONOTEVALUATE} get a ReferenceError, which is fine: they are
+     * always parse-phase negative tests where the function is never reached.
+     */
+    private static final String HOST_BINDINGS_JS =
+            "var print = function() {\n" +
+            "  var s = '';\n" +
+            "  for (var i = 0; i < arguments.length; i++) {\n" +
+            "    if (i > 0) s += ' ';\n" +
+            "    s += String(arguments[i]);\n" +
+            "  }\n" +
+            "  console.log(s);\n" +
+            "};\n" +
+            // Indirect eval via an alias: assigning `eval` to a local before invoking it
+            // is an ES spec "indirect eval", which evaluates at the realm's global scope
+            // (matching INTERPRETING.md's ParseScript + ScriptEvaluation semantics).
+            // The classic `(0, eval)(src)` form is semantically equivalent but isn't
+            // accepted by karate-js's parser today.
+            "var $262 = {\n" +
+            "  global: (function(){ return this; })(),\n" +
+            "  evalScript: function(src) { var indirect = eval; return indirect(src); },\n" +
+            "  gc: function() { throw new Error('gc not supported'); },\n" +
+            "  detachArrayBuffer: function() { throw new Error('detachArrayBuffer not supported'); },\n" +
+            "  createRealm: function() { throw new Error('createRealm not supported'); },\n" +
+            "  agent: { start: function() { throw new Error('agents not supported'); } }\n" +
+            "};\n";
+
+    /* ------------------------------- helpers ------------------------------- */
+
+    private static Pattern globToRegex(String glob) {
+        StringBuilder sb = new StringBuilder("^");
+        int i = 0;
+        while (i < glob.length()) {
+            char c = glob.charAt(i);
+            if (c == '*') {
+                if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                    sb.append(".*");
+                    i += 2;
+                    if (i < glob.length() && glob.charAt(i) == '/') i++;
+                    continue;
+                }
+                sb.append("[^/]*");
+            } else if (c == '?') {
+                sb.append('.');
+            } else if ("\\.^$+()[]{}|".indexOf(c) >= 0) {
+                sb.append('\\').append(c);
+            } else {
+                sb.append(c);
+            }
+            i++;
+        }
+        sb.append('$');
+        return Pattern.compile(sb.toString());
+    }
+
+    private static Set<String> loadExistingPaths(Path jsonl) {
+        if (!Files.isRegularFile(jsonl)) return Set.of();
+        Set<String> out = new HashSet<>();
+        try (BufferedReader br = Files.newBufferedReader(jsonl, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                int idx = line.indexOf("\"path\":\"");
+                if (idx < 0) continue;
+                int start = idx + "\"path\":\"".length();
+                int end = line.indexOf('"', start);
+                if (end > start) out.add(line.substring(start, end));
+            }
+        } catch (IOException e) {
+            return Set.of();
+        }
+        return out;
+    }
+
+    private static List<ResultRecord> loadExistingRecords(Path jsonl, java.util.function.Predicate<String> keepByPath) {
+        // Minimal parse to reuse prior records on --resume; we only need to echo them back.
+        List<ResultRecord> out = new ArrayList<>();
+        if (!Files.isRegularFile(jsonl)) return out;
+        try (BufferedReader br = Files.newBufferedReader(jsonl, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                String path = between(line, "\"path\":\"", "\"");
+                if (path == null || !keepByPath.test(path)) continue;
+                String status = between(line, "\"status\":\"", "\"");
+                String errorType = between(line, "\"error_type\":\"", "\"");
+                String message = between(line, "\"message\":\"", "\"");
+                String reason = between(line, "\"reason\":\"", "\"");
+                if (status == null) continue;
+                out.add(new ResultRecord(
+                        path,
+                        ResultRecord.Status.valueOf(status),
+                        errorType, message, reason));
+            }
+        } catch (IOException e) {
+            return Collections.emptyList();
+        }
+        return out;
+    }
+
+    private static String between(String line, String left, String right) {
+        int i = line.indexOf(left);
+        if (i < 0) return null;
+        int s = i + left.length();
+        int e = line.indexOf(right, s);
+        if (e < 0) return null;
+        return line.substring(s, e);
+    }
+
+    private static boolean containsPath(List<ResultRecord> records, String path) {
+        for (ResultRecord r : records) if (r.path().equals(path)) return true;
+        return false;
+    }
+
+    private static String readTest262Sha(Path test262Root) {
+        Path head = test262Root.resolve(".git/HEAD");
+        try {
+            String h = Files.readString(head).strip();
+            if (h.startsWith("ref: ")) {
+                Path refFile = test262Root.resolve(".git").resolve(h.substring(5).strip());
+                if (Files.isRegularFile(refFile)) return Files.readString(refFile).strip();
+            }
+            return h;
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    private static String readHeadSha(Path repoRoot) {
+        if (repoRoot == null) return "";
+        Path head = repoRoot.resolve(".git/HEAD");
+        try {
+            String h = Files.readString(head).strip();
+            if (h.startsWith("ref: ")) {
+                Path refFile = repoRoot.resolve(".git").resolve(h.substring(5).strip());
+                if (Files.isRegularFile(refFile)) return Files.readString(refFile).strip().substring(0, 10);
+            }
+            return h.length() >= 10 ? h.substring(0, 10) : h;
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    private static String formatDuration(java.time.Duration d) {
+        long total = d.toSeconds();
+        long m = total / 60;
+        long s = total % 60;
+        return m + "m" + (s < 10 ? "0" : "") + s + "s";
+    }
+}

--- a/karate-js-test262/src/main/resources/report/app.js
+++ b/karate-js-test262/src/main/resources/report/app.js
@@ -1,0 +1,56 @@
+// Client-side filter/search for index.html. All data is already in the DOM.
+
+(function () {
+  // Render run-meta block.
+  try {
+    const raw = document.getElementById('run-meta').textContent;
+    const meta = JSON.parse(raw);
+    const el = document.getElementById('meta');
+    if (el && meta) {
+      const lines = [];
+      if (meta.test262_sha)      lines.push('test262 SHA     ' + meta.test262_sha);
+      if (meta.karate_js_git_sha)lines.push('karate-js SHA   ' + meta.karate_js_git_sha);
+      if (meta.jdk)              lines.push('JDK             ' + meta.jdk);
+      if (meta.os)               lines.push('OS              ' + meta.os);
+      if (meta.started_at)       lines.push('started         ' + meta.started_at);
+      if (meta.elapsed_ms != null) lines.push('elapsed         ' + (meta.elapsed_ms / 1000).toFixed(1) + 's');
+      el.textContent = lines.join('\n');
+    }
+  } catch (e) { /* no meta, fine */ }
+
+  const input = document.getElementById('q');
+  const statusFilters = document.querySelectorAll('.status-filter');
+  const items = document.querySelectorAll('#tree li.t');
+
+  function refresh() {
+    const q = (input?.value || '').toLowerCase().trim();
+    const allowed = new Set();
+    statusFilters.forEach(cb => { if (cb.checked) allowed.add(cb.dataset.s); });
+
+    // Track which <details> actually contain a visible test; collapse empties.
+    const visibleCountByDetails = new WeakMap();
+
+    items.forEach(li => {
+      const path = (li.dataset.path || '').toLowerCase();
+      const status = li.querySelector('.status')?.textContent?.trim();
+      const match = (!q || path.includes(q)) && allowed.has(status);
+      li.classList.toggle('hidden', !match);
+      if (match) {
+        // Bubble up: mark every ancestor <details> as containing a visible item.
+        let d = li.closest('details');
+        while (d) {
+          visibleCountByDetails.set(d, (visibleCountByDetails.get(d) || 0) + 1);
+          d = d.parentElement?.closest('details');
+        }
+      }
+    });
+
+    document.querySelectorAll('#tree details').forEach(d => {
+      const hasVisible = (visibleCountByDetails.get(d) || 0) > 0;
+      d.classList.toggle('hidden', !hasVisible);
+    });
+  }
+
+  input?.addEventListener('input', refresh);
+  statusFilters.forEach(cb => cb.addEventListener('change', refresh));
+})();

--- a/karate-js-test262/src/main/resources/report/styles.css
+++ b/karate-js-test262/src/main/resources/report/styles.css
@@ -1,0 +1,52 @@
+* { box-sizing: border-box; }
+html { font: 14px/1.45 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #222; }
+body { margin: 0; padding: 1.25rem 1.5rem 3rem; max-width: 1100px; }
+
+h1 { margin: 0 0 .25rem; font-size: 1.4rem; font-weight: 600; }
+h2 { margin: 1.5rem 0 .5rem; font-size: 1rem; font-weight: 600; color: #555; border-bottom: 1px solid #eee; padding-bottom: .25rem; }
+
+header { margin-bottom: 1rem; }
+
+#meta { color: #777; font-size: .85rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; margin: .3rem 0 .8rem; }
+
+.summary { display: flex; gap: .35rem; align-items: center; margin: .4rem 0 .8rem; flex-wrap: wrap; }
+.pill { display: inline-block; padding: 0.2rem 0.55rem; border-radius: 1rem; font-size: .8rem; font-weight: 500; }
+.pill.pass  { background: #e8f5e9; color: #2e7d32; }
+.pill.fail  { background: #ffebee; color: #c62828; }
+.pill.skip  { background: #f5f5f5; color: #616161; }
+.pill.total { background: #eceff1; color: #455a64; }
+
+.filters { display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; font-size: .9rem; margin: .3rem 0; }
+.filters input[type=text], .filters #q { flex: 1 1 240px; padding: .35rem .55rem; font: inherit; border: 1px solid #ccc; border-radius: 4px; }
+
+ul.top-stats { list-style: none; padding: 0; margin: 0; }
+ul.top-stats li { padding: .3rem 0; border-bottom: 1px dashed #eee; display: flex; align-items: center; gap: .75rem; font-family: ui-monospace, monospace; font-size: .9rem; }
+ul.top-stats li strong { min-width: 10rem; font-weight: 600; }
+.bar svg { vertical-align: middle; display: inline-block; border-radius: 2px; }
+.counts { color: #666; font-size: .85rem; }
+
+#tree details { margin: .15rem 0; padding-left: .4rem; border-left: 2px solid transparent; }
+#tree details[open] { border-left-color: #e0e0e0; }
+#tree summary { cursor: pointer; padding: .15rem .25rem; display: flex; gap: .5rem; align-items: center; }
+#tree summary:hover { background: #fafafa; }
+#tree .dir { font-family: ui-monospace, monospace; color: #455a64; font-weight: 500; }
+#tree details details { margin-left: 1rem; }
+#tree details ul.tests { margin-left: 1.5rem; list-style: none; padding-left: 0; }
+#tree details ul.tests li { padding: .1rem .25rem; font-family: ui-monospace, monospace; font-size: .85rem; display: flex; gap: .5rem; align-items: baseline; }
+#tree details ul.tests li.t-PASS { color: #444; }
+#tree details ul.tests li.t-PASS .status { color: #2e7d32; font-weight: 600; }
+#tree details ul.tests li.t-FAIL .status { color: #c62828; font-weight: 600; }
+#tree details ul.tests li.t-SKIP { color: #888; }
+#tree details ul.tests li.t-SKIP .status { color: #888; font-weight: 600; }
+#tree details ul.tests li a { color: #1565c0; text-decoration: none; }
+#tree details ul.tests li a:hover { text-decoration: underline; }
+#tree details ul.tests li em { color: #888; font-style: italic; font-size: .8rem; margin-left: .2rem; }
+#tree details ul.tests li.hidden, #tree details.hidden { display: none; }
+
+pre { background: #fafafa; border: 1px solid #eee; border-radius: 4px; padding: .6rem .8rem; overflow: auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; line-height: 1.45; }
+pre.error { background: #ffebee; border-color: #ffcdd2; color: #b71c1c; white-space: pre-wrap; }
+pre.cmd   { background: #263238; color: #eceff1; border-color: #263238; user-select: all; }
+pre.source .ln { color: #9e9e9e; display: inline-block; width: auto; user-select: none; margin-right: .3rem; }
+
+a { color: #1565c0; }
+a:hover { text-decoration: underline; }

--- a/karate-js-test262/src/test/java/io/karatelabs/js/test262/CliTest.java
+++ b/karate-js-test262/src/test/java/io/karatelabs/js/test262/CliTest.java
@@ -1,0 +1,44 @@
+package io.karatelabs.js.test262;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CliTest {
+
+    @Test
+    void testRawArgsDoesNotDuplicateFlagValues() {
+        // regression: value-bearing flags used to append their value twice to rawArgs,
+        // producing corrupted `cli_args` in run-meta.json.
+        Cli c = Cli.parse(new String[] {
+                "--timeout-ms", "5000",
+                "--only", "test/language/**",
+                "--resume",
+                "--single", "test/foo.js"
+        });
+        assertEquals(7, c.rawArgs.size(), c.rawArgs.toString());
+        assertEquals("--timeout-ms", c.rawArgs.get(0));
+        assertEquals("5000", c.rawArgs.get(1));
+        assertEquals("--only", c.rawArgs.get(2));
+        assertEquals("test/language/**", c.rawArgs.get(3));
+        assertEquals("--resume", c.rawArgs.get(4));
+        assertEquals("--single", c.rawArgs.get(5));
+        assertEquals("test/foo.js", c.rawArgs.get(6));
+    }
+
+    @Test
+    void testVerboseFlags() {
+        assertEquals(1, Cli.parse(new String[] { "-v" }).verbose);
+        assertEquals(2, Cli.parse(new String[] { "-vv" }).verbose);
+        assertEquals(0, Cli.parse(new String[] {}).verbose);
+    }
+
+    @Test
+    void testDefaults() {
+        Cli c = Cli.parse(new String[] {});
+        assertEquals(10_000L, c.timeoutMs);
+        assertNull(c.only);
+        assertNull(c.single);
+        assertFalse(c.resume);
+    }
+}

--- a/karate-js-test262/src/test/java/io/karatelabs/js/test262/ErrorUtilsTest.java
+++ b/karate-js-test262/src/test/java/io/karatelabs/js/test262/ErrorUtilsTest.java
@@ -1,0 +1,77 @@
+package io.karatelabs.js.test262;
+
+import io.karatelabs.js.EngineException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ErrorUtilsTest {
+
+    @Test
+    void testStructuredNameTakesPrecedence() {
+        // Even if the message mentions TypeError, the structured name wins.
+        EngineException ee = new EngineException(
+                "Error: TypeError mentioned but actually Error", null, "Error");
+        assertEquals("Error", ErrorUtils.classify(ee));
+    }
+
+    @Test
+    void testStructuredNameCanonicalized() {
+        EngineException ee = new EngineException("whatever", null, "typeerror");
+        assertEquals("TypeError", ErrorUtils.classify(ee));
+    }
+
+    @Test
+    void testClassifyTypeErrorPrefix() {
+        assertEquals("TypeError", ErrorUtils.classify(new RuntimeException("TypeError: foo")));
+    }
+
+    @Test
+    void testClassifyRangeErrorPrefix() {
+        assertEquals("RangeError", ErrorUtils.classify(new RuntimeException("RangeError: out of bounds")));
+    }
+
+    @Test
+    void testClassifyFramedErrorFindsTypedName() {
+        // Engine framing often decorates: "js failed: ... Error: TypeError: x"
+        String msg = "js failed:\n==========\n  Error: TypeError: nope\n==========";
+        assertEquals("TypeError", ErrorUtils.classify(new RuntimeException(msg)));
+    }
+
+    @Test
+    void testClassifyReferenceErrorFromIsNotDefined() {
+        assertEquals("ReferenceError", ErrorUtils.classify(new RuntimeException("foo is not defined")));
+    }
+
+    @Test
+    void testClassifyUnknownReturnsNull() {
+        assertNull(ErrorUtils.classify(new RuntimeException("something weird happened")));
+    }
+
+    @Test
+    void testClassifyWalksCauseChainForStructuredName() {
+        EngineException inner = new EngineException("TypeError: x", null, "TypeError");
+        RuntimeException outer = new RuntimeException("wrapped", inner);
+        assertEquals("TypeError", ErrorUtils.classify(outer));
+    }
+
+    @Test
+    void testClassifyWalksCauseChainForMessagePrefix() {
+        Throwable inner = new RuntimeException("TypeError: deep");
+        Throwable outer = new RuntimeException("generic wrapper", inner);
+        assertEquals("TypeError", ErrorUtils.classify(outer));
+    }
+
+    @Test
+    void testFirstLineTruncation() {
+        assertEquals("abc", ErrorUtils.firstLine("abc\ndef", 100));
+        assertNull(ErrorUtils.firstLine(null, 100));
+        assertTrue(ErrorUtils.firstLine("x".repeat(500), 50).length() <= 50);
+    }
+
+    @Test
+    void testFirstLineUnwrapsFraming() {
+        String msg = "js failed:\n==========\n  File: foo.js\n  Code: bar\n  Error: real problem here\n==========";
+        assertEquals("real problem here", ErrorUtils.firstLine(msg, 200));
+    }
+}

--- a/karate-js-test262/src/test/java/io/karatelabs/js/test262/ExpectationsTest.java
+++ b/karate-js-test262/src/test/java/io/karatelabs/js/test262/ExpectationsTest.java
@@ -1,0 +1,85 @@
+package io.karatelabs.js.test262;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExpectationsTest {
+
+    @Test
+    void testLoadsBundledExpectations() {
+        Path yaml = Paths.get("config/expectations.yaml");
+        assumeExists(yaml);
+        Expectations exp = Expectations.load(yaml);
+
+        // A test under intl402 should be skipped due to path rule.
+        Test262Case intl = syntheticCase("test/intl402/Date/prototype/toLocaleString.js", Test262Metadata.empty());
+        assertNotNull(exp.matchSkip(intl));
+
+        // A test under language/expressions/addition should NOT be skipped by path.
+        Test262Case ok = syntheticCase("test/language/expressions/addition/S11.6.1_A1.js", Test262Metadata.empty());
+        assertNull(exp.matchSkip(ok));
+    }
+
+    @Test
+    void testFlagsSkip() {
+        Path yaml = Paths.get("config/expectations.yaml");
+        assumeExists(yaml);
+        Expectations exp = Expectations.load(yaml);
+
+        Test262Metadata m = new Test262Metadata(
+                java.util.List.of("module"), java.util.List.of(), java.util.List.of(),
+                null, false, null);
+        Test262Case c = syntheticCase("test/language/module-code/foo.js", m);
+        String reason = exp.matchSkip(c);
+        assertNotNull(reason);
+        assertTrue(reason.toLowerCase().contains("module"), reason);
+    }
+
+    @Test
+    void testFeaturesSkip() {
+        Path yaml = Paths.get("config/expectations.yaml");
+        assumeExists(yaml);
+        Expectations exp = Expectations.load(yaml);
+
+        Test262Metadata m = new Test262Metadata(
+                java.util.List.of(), java.util.List.of("BigInt"), java.util.List.of(),
+                null, false, null);
+        Test262Case c = syntheticCase("test/language/bigint.js", m);
+        String reason = exp.matchSkip(c);
+        assertNotNull(reason);
+        assertTrue(reason.toLowerCase().contains("bigint"), reason);
+    }
+
+    @Test
+    void testIncludesSkip() {
+        Path yaml = Paths.get("config/expectations.yaml");
+        assumeExists(yaml);
+        Expectations exp = Expectations.load(yaml);
+
+        Test262Metadata m = new Test262Metadata(
+                java.util.List.of(), java.util.List.of(),
+                java.util.List.of("assert.js", "propertyHelper.js"),
+                null, false, null);
+        Test262Case c = syntheticCase("test/built-ins/Object/proto.js", m);
+        String reason = exp.matchSkip(c);
+        assertNotNull(reason);
+        // propertyHelper.js is in the starter skip list
+        assertTrue(reason.toLowerCase().contains("internals")
+                || reason.toLowerCase().contains("property"), reason);
+    }
+
+    private static Test262Case syntheticCase(String relPath, Test262Metadata m) {
+        return new Test262Case(relPath, Path.of(relPath), "", m);
+    }
+
+    private static void assumeExists(Path p) {
+        if (!Files.isRegularFile(p)) {
+            throw new org.opentest4j.TestAbortedException("expectations.yaml not found: " + p.toAbsolutePath());
+        }
+    }
+}

--- a/karate-js-test262/src/test/java/io/karatelabs/js/test262/Test262MetadataTest.java
+++ b/karate-js-test262/src/test/java/io/karatelabs/js/test262/Test262MetadataTest.java
@@ -1,0 +1,101 @@
+package io.karatelabs.js.test262;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Test262MetadataTest {
+
+    @Test
+    void testNoFrontmatter() {
+        Test262Metadata m = Test262Metadata.parse("var x = 1;");
+        assertTrue(m.flags().isEmpty());
+        assertTrue(m.features().isEmpty());
+        assertTrue(m.includes().isEmpty());
+        assertNull(m.negative());
+        assertFalse(m.raw());
+    }
+
+    @Test
+    void testFlagsAndFeatures() {
+        String src = """
+            /*---
+            description: foo
+            flags: [noStrict]
+            features: [Symbol, BigInt]
+            ---*/
+            var x;
+            """;
+        Test262Metadata m = Test262Metadata.parse(src);
+        assertEquals(1, m.flags().size());
+        assertTrue(m.flags().contains("noStrict"));
+        assertEquals(2, m.features().size());
+        assertTrue(m.features().contains("Symbol"));
+        assertTrue(m.features().contains("BigInt"));
+        assertEquals("foo", m.description());
+    }
+
+    @Test
+    void testIncludes() {
+        String src = """
+            /*---
+            includes: [assert.js, sta.js, propertyHelper.js]
+            ---*/
+            """;
+        Test262Metadata m = Test262Metadata.parse(src);
+        assertEquals(3, m.includes().size());
+        assertEquals("assert.js", m.includes().get(0));
+        assertEquals("propertyHelper.js", m.includes().get(2));
+    }
+
+    @Test
+    void testNegative() {
+        String src = """
+            /*---
+            negative:
+              phase: parse
+              type: SyntaxError
+            ---*/
+            """;
+        Test262Metadata m = Test262Metadata.parse(src);
+        assertNotNull(m.negative());
+        assertEquals("parse", m.negative().phase());
+        assertEquals("SyntaxError", m.negative().type());
+    }
+
+    @Test
+    void testRaw() {
+        String src = """
+            /*---
+            flags: [raw]
+            ---*/
+            """;
+        Test262Metadata m = Test262Metadata.parse(src);
+        assertTrue(m.raw());
+    }
+
+    @Test
+    void testEmptyInlineArray() {
+        assertTrue(Test262Metadata.parseInlineArray("[]").isEmpty());
+        assertTrue(Test262Metadata.parseInlineArray("  [ ] ").isEmpty());
+    }
+
+    @Test
+    void testNegativeFollowedByOtherKey() {
+        // ensure state transition out of "negative:" block works
+        String src = """
+            /*---
+            negative:
+              phase: runtime
+              type: TypeError
+            features: [Symbol]
+            ---*/
+            """;
+        Test262Metadata m = Test262Metadata.parse(src);
+        assertNotNull(m.negative());
+        assertEquals("runtime", m.negative().phase());
+        assertEquals("TypeError", m.negative().type());
+        assertEquals(1, m.features().size());
+        assertEquals("Symbol", m.features().get(0));
+    }
+}

--- a/karate-js-test262/src/test/java/io/karatelabs/js/test262/Test262ReportEmbedTest.java
+++ b/karate-js-test262/src/test/java/io/karatelabs/js/test262/Test262ReportEmbedTest.java
@@ -1,0 +1,71 @@
+package io.karatelabs.js.test262;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards against a class of bug where {@code run-meta.json} embedded inside
+ * {@code <script type="application/json">} gets HTML-entity-escaped, making it
+ * unparseable by {@code JSON.parse} in the browser (entities aren't decoded
+ * inside that tag). Verifies the JSON survives embed→extract round-trip.
+ */
+class Test262ReportEmbedTest {
+
+    @Test
+    void testRunMetaEmbedIsJsonParseable(@org.junit.jupiter.api.io.TempDir Path tmp) throws Exception {
+        Path results = tmp.resolve("results.jsonl");
+        Path runMeta = tmp.resolve("run-meta.json");
+        Path out = tmp.resolve("html");
+
+        // minimal but realistic fixture
+        Files.writeString(results,
+                "{\"path\":\"test/language/foo.js\",\"status\":\"PASS\"}\n" +
+                "{\"path\":\"test/language/bar.js\",\"status\":\"FAIL\",\"error_type\":\"TypeError\",\"message\":\"x\"}\n");
+        // Include a sneaky "</script" substring to confirm the neutralization.
+        String meta = """
+            {
+              "test262_sha": "abc123",
+              "karate_js_version": "2.0.5.RC1",
+              "note": "trap: </script> should not break the page",
+              "counts": { "pass": 1, "fail": 1, "skip": 0, "total": 2 }
+            }
+            """;
+        Files.writeString(runMeta, meta);
+
+        Test262Report.main(new String[] {
+                "--results", results.toString(),
+                "--run-meta", runMeta.toString(),
+                "--test262", tmp.toString(),
+                "--out", out.toString()
+        });
+
+        String html = Files.readString(out.resolve("index.html"));
+        // The page must not have been terminated early by the sneaky </script>.
+        assertTrue(html.contains("<script id=\"run-meta\" type=\"application/json\">"), html);
+        // The literal </script> in JSON must have been neutralized (backslash-escaped).
+        assertTrue(html.contains("<\\/script>"), "expected neutralized </script> in embed");
+        // And the JSON inside must not contain HTML entities.
+        Matcher m = Pattern.compile(
+                "<script id=\"run-meta\"[^>]*>(.*?)</script>", Pattern.DOTALL).matcher(html);
+        assertTrue(m.find(), "could not locate embed");
+        String embedded = m.group(1).strip();
+        assertFalse(embedded.contains("&quot;"), "JSON must not be HTML-escaped: " + embedded);
+        assertFalse(embedded.contains("&amp;"), "JSON must not be HTML-escaped");
+
+        // The embed should JSON-decode cleanly after reversing the </script> neutralization.
+        // Browsers do NOT reverse HTML entities inside <script type="application/json">; they
+        // DO see the raw bytes. We wrote "<\/script" which is a valid JSON escape for "</script".
+        String decoded = embedded.replace("<\\/", "</");
+        // Smoke-test: the decoded string starts with '{' and contains expected keys.
+        assertTrue(decoded.trim().startsWith("{"), decoded);
+        assertTrue(decoded.contains("\"test262_sha\""), decoded);
+        assertTrue(decoded.contains("\"abc123\""), decoded);
+    }
+}

--- a/karate-js/src/main/java/io/karatelabs/js/Engine.java
+++ b/karate-js/src/main/java/io/karatelabs/js/Engine.java
@@ -27,6 +27,7 @@ import io.karatelabs.common.Resource;
 import io.karatelabs.parser.JsParser;
 import io.karatelabs.parser.Node;
 import io.karatelabs.parser.NodeType;
+import io.karatelabs.parser.ParserException;
 
 import java.io.File;
 import java.util.Map;
@@ -186,15 +187,23 @@ public class Engine {
                 // flow-control signal from a host function — pass through unchanged
                 throw (RuntimeException) e;
             }
+            if (e instanceof ParserException pe) {
+                // preserve parser-failure type so callers can distinguish parse phase
+                throw pe;
+            }
             String message = e.getMessage();
             if (message == null) {
                 message = e + "";
             }
             Resource resource = program.getFirstToken().getResource();
-            if (resource.isFile()) {
-                message = message + "\n" + resource.getRelativePath();
+            String relPath = resource.isFile() ? resource.getRelativePath() : null;
+            if (relPath != null && !message.endsWith(relPath)) {
+                message = message + "\n" + relPath;
             }
-            throw new RuntimeException(message);
+            // Preserve structured jsErrorName when we already have an EngineException
+            // (e.g., from Interpreter.evalProgram for uncaught JS throws).
+            String jsErrorName = e instanceof EngineException ee ? ee.getJsErrorName() : null;
+            throw new EngineException(message, e, jsErrorName);
         }
     }
 

--- a/karate-js/src/main/java/io/karatelabs/js/EngineException.java
+++ b/karate-js/src/main/java/io/karatelabs/js/EngineException.java
@@ -25,8 +25,29 @@ package io.karatelabs.js;
 
 public class EngineException extends RuntimeException {
 
-    EngineException(String message, Throwable cause) {
+    private final String jsErrorName;
+
+    public EngineException(String message, Throwable cause) {
+        this(message, cause, null);
+    }
+
+    /**
+     * @param jsErrorName canonical JS error constructor name
+     *                    ("TypeError" | "ReferenceError" | "RangeError" | "SyntaxError" |
+     *                     "URIError" | "EvalError" | "Error" | null if non-JS origin)
+     */
+    public EngineException(String message, Throwable cause, String jsErrorName) {
         super(message, cause);
+        this.jsErrorName = jsErrorName;
+    }
+
+    /**
+     * @return the JS error constructor name when this exception originated from
+     *         an uncaught JS {@code throw}; {@code null} for Java-origin errors
+     *         (the caller can still inspect {@link #getMessage()} or the cause chain).
+     */
+    public String getJsErrorName() {
+        return jsErrorName;
     }
 
 }

--- a/karate-js/src/main/java/io/karatelabs/js/Interpreter.java
+++ b/karate-js/src/main/java/io/karatelabs/js/Interpreter.java
@@ -755,14 +755,25 @@ class Interpreter {
             if (context.isError()) {
                 Object errorThrown = context.getErrorThrown();
                 String errorMessage = null;
+                String errorName = null;
                 if (errorThrown instanceof JsObject jsError) {
                     Object message = jsError.getMember("message");
                     if (message instanceof String) {
                         errorMessage = (String) message;
                     }
+                    Object name = jsError.getMember("name");
+                    if (name instanceof String) {
+                        errorName = (String) name;
+                    }
                 }
-                String message = child.toStringError(errorMessage == null ? errorThrown.toString() : errorMessage);
-                throw new RuntimeException(message);
+                String rawMessage = errorMessage == null ? errorThrown.toString() : errorMessage;
+                // Keep a readable prefix in the message for logging, but the structured
+                // errorName is what callers (like the test262 runner) should consult.
+                if (errorName != null && !rawMessage.startsWith(errorName + ":")) {
+                    rawMessage = errorName + ": " + rawMessage;
+                }
+                String message = child.toStringError(rawMessage);
+                throw new EngineException(message, null, errorName);
             }
         }
         return progResult;

--- a/karate-js/src/test/java/io/karatelabs/js/EngineExceptionTest.java
+++ b/karate-js/src/test/java/io/karatelabs/js/EngineExceptionTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 Karate Labs Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.karatelabs.js;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EngineExceptionTest {
+
+    private static EngineException assertThrowsEngineException(String script) {
+        Engine engine = new Engine();
+        return assertThrows(EngineException.class, () -> engine.eval(script));
+    }
+
+    @Test
+    void testTopLevelThrowTypeError() {
+        EngineException ex = assertThrowsEngineException("throw new TypeError('bad arg')");
+        assertTrue(ex.getMessage().contains("TypeError:"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("bad arg"), ex.getMessage());
+        assertEquals("TypeError", ex.getJsErrorName());
+    }
+
+    @Test
+    void testTopLevelThrowError() {
+        EngineException ex = assertThrowsEngineException("throw new Error('boom')");
+        assertTrue(ex.getMessage().contains("Error:"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("boom"), ex.getMessage());
+        assertEquals("Error", ex.getJsErrorName());
+    }
+
+    @Test
+    void testTopLevelThrowCustomNamedError() {
+        // simulate a RangeError via user-assigned name (engine does not pre-register RangeError)
+        EngineException ex = assertThrowsEngineException(
+                "var e = new Error('out of bounds'); e.name = 'RangeError'; throw e;");
+        assertTrue(ex.getMessage().contains("RangeError:"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("out of bounds"), ex.getMessage());
+        assertEquals("RangeError", ex.getJsErrorName());
+    }
+
+    @Test
+    void testStructuredNameDistinguishesErrorFromInnerTypeErrorMention() {
+        // new Error('TypeError: x') must classify as Error, not TypeError —
+        // structured name trumps any substring match on the message.
+        EngineException ex = assertThrowsEngineException(
+                "throw new Error('TypeError: look elsewhere')");
+        assertEquals("Error", ex.getJsErrorName());
+    }
+
+    @Test
+    void testReferenceToUndefinedVar() {
+        EngineException ex = assertThrowsEngineException("noSuchVariable");
+        assertTrue(ex.getMessage().contains("noSuchVariable"), ex.getMessage());
+        // engine-origin error — not from a JS `throw`, so no structured name
+        assertNull(ex.getJsErrorName());
+    }
+
+    @Test
+    void testEngineProducedTypeErrorPrefix() {
+        // Prototype.putMember emits "TypeError: Cannot add property ..."
+        EngineException ex = assertThrowsEngineException("Array.prototype.foo = 1");
+        assertTrue(ex.getMessage().contains("TypeError:"), ex.getMessage());
+        // engine-origin; structured name is null, message-prefix classification kicks in
+        assertNull(ex.getJsErrorName());
+    }
+
+    @Test
+    void testEngineProducedRangeErrorPrefix() {
+        // JsNumberPrototype emits "RangeError: precision must be between 1 and 100"
+        EngineException ex = assertThrowsEngineException("(123).toPrecision(0)");
+        assertTrue(ex.getMessage().contains("RangeError:"), ex.getMessage());
+        assertNull(ex.getJsErrorName());
+    }
+
+    @Test
+    void testEngineExceptionPreservesCause() {
+        EngineException ex = assertThrowsEngineException("throw new TypeError('x')");
+        assertNotNull(ex.getCause(), "cause should not be null");
+    }
+}

--- a/karate-js/src/test/java/io/karatelabs/js/ParserExceptionTest.java
+++ b/karate-js/src/test/java/io/karatelabs/js/ParserExceptionTest.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 Karate Labs Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.karatelabs.js;
+
+import io.karatelabs.parser.ParserException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParserExceptionTest {
+
+    @Test
+    void testParseFailureSurfacesAsParserException() {
+        Engine engine = new Engine();
+        // malformed: var declaration with no initializer expression
+        assertThrows(ParserException.class, () -> engine.eval("var x = ;"));
+    }
+
+    @Test
+    void testParseFailureNotWrappedAsEngineException() {
+        Engine engine = new Engine();
+        try {
+            engine.eval("function foo( { }");
+            fail("expected a parser exception");
+        } catch (ParserException pe) {
+            // expected
+        } catch (EngineException ee) {
+            fail("parse error should not be wrapped as EngineException: " + ee);
+        }
+    }
+
+    @Test
+    void testRuntimeErrorIsNotParserException() {
+        Engine engine = new Engine();
+        try {
+            engine.eval("throw new Error('runtime')");
+            fail("expected a runtime error");
+        } catch (ParserException pe) {
+            fail("runtime error should not surface as ParserException: " + pe);
+        } catch (EngineException ee) {
+            // expected
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 		<module>karate-core</module>
 		<module>karate-junit6</module>
 		<module>karate-gatling</module>
+		<module>karate-js-test262</module>
 	</modules>
 
     <dependencies>


### PR DESCRIPTION
## Summary

- **New module `karate-js-test262`** — tc39/test262 conformance harness for karate-js. Declarative skip list in `config/expectations.yaml`, sequential runner with per-test watchdog, JSONL results, static HTML dashboard with per-failure drill-down, and a `workflow_dispatch`-only CI (`.github/workflows/test262.yml`). Module is explicitly excluded from Maven Central deployment (`maven.deploy.skip=true`, `skipPublishing=true`, source/javadoc/gpg all off).
- **Minimal engine changes** — `EngineException` now carries an optional `getJsErrorName()` so runtime JS errors surface their constructor name (`TypeError`/`RangeError`/…) without message-string sniffing. `Engine.eval` preserves `ParserException` and the structured name when rewrapping. The runner's `ErrorUtils` prefers the structured name with message-prefix fallback.
- **Living document** — [`karate-js-test262/README.md`](../blob/feat/test262-harness/karate-js-test262/README.md) captures working principles (real-world LLM-written JS as the bar; fix friction in engine/harness before moving on; event system is fair game for testability; performance via `EngineBenchmark`), a tier-based roadmap, known first-order gaps (missing `ReferenceError`/`RangeError` globals; comma/sequence operator not accepted inside parens), recipes, and deferred TODOs.

## Test plan

- [x] `mvn -pl karate-js-test262,karate-js -am test` — 774 engine tests + 26 harness unit tests, all green
- [x] End-to-end smoke: `./fetch-test262.sh` + `--only test/language/expressions/addition/**` produces 17 pass / 23 fail / 8 skip on 48 files; HTML report renders with working meta header (regression-tested via `Test262ReportEmbedTest`)
- [x] `--single <path> -vv` works for debugging a single failing test
- [x] Dry-run `mvn deploy` on the new module logs `Skipping artifact deployment` (no accidental Maven Central publish)
- [ ] Reviewer: run `./karate-js-test262/fetch-test262.sh` + the `--only` command above locally to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)