### PR TITLE
fix: set suite end time before firing SUITE_EXIT event

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/Suite.java
+++ b/karate-core/src/main/java/io/karatelabs/core/Suite.java
@@ -323,10 +323,15 @@ public class Suite {
                 runSequential();
             }
 
+            // set end time before firing SUITE_EXIT so the event carries a valid durationMillis
+            result.setEndTime(System.currentTimeMillis());
+
             // Fire SUITE_EXIT event
             fireEvent(SuiteRunEvent.exit(this, result));
         } finally {
-            result.setEndTime(System.currentTimeMillis());
+            if (result.getEndTime() == 0) {
+                result.setEndTime(System.currentTimeMillis());
+            }
 
             // Shutdown driver provider if one exists
             if (driverProvider != null) {

--- a/karate-core/src/test/java/io/karatelabs/output/JsonLinesEventWriterTest.java
+++ b/karate-core/src/test/java/io/karatelabs/output/JsonLinesEventWriterTest.java
@@ -225,6 +225,8 @@ class JsonLinesEventWriterTest {
         assertEquals(0, ((Number) summary.get("scenariosFailed")).intValue());
         assertEquals(100, ((Number) summary.get("passedRate")).intValue());
         assertTrue(summary.containsKey("durationMillis"));
+        assertTrue(((Number) summary.get("durationMillis")).longValue() >= 0,
+                "durationMillis in SUITE_EXIT must not be negative");
     }
 
     @Test


### PR DESCRIPTION
## Description

The `SUITE_EXIT` event was fired before `SuiteResult.setEndTime(...)` was called, so the serialized `summary.durationMillis` in `karate-events.jsonl` was `0 - startTime`, a large negative value. This sets the end time before firing the event and keeps the `finally` block as a fallback when an exception skips the event.

## Related Issues

- Fixes #2843

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [ ] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
