### PR TITLE
ensure `karate.get` and `karate.jsonPath` do not throw on missing fields

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/KarateJs.java
+++ b/karate-core/src/main/java/io/karatelabs/core/KarateJs.java
@@ -23,7 +23,9 @@
  */
 package io.karatelabs.core;
 
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
 import io.karatelabs.common.*;
 import io.karatelabs.gherkin.Feature;
 import io.karatelabs.gherkin.MatchExpression;
@@ -73,6 +75,8 @@ public class KarateJs extends KarateJsBase implements PerfContext {
     private static final Faker FAKER = new Faker();
 
     private final JavaCallable read;
+    private final Configuration jsonPathConfig = Configuration.defaultConfiguration()
+            .addOptions(Option.SUPPRESS_EXCEPTIONS);
 
     public KarateJs(Resource root) {
         this(root, new DefaultHttpClientFactory());
@@ -491,14 +495,14 @@ public class KarateJs extends KarateJsBase implements PerfContext {
                     String jsonPath = "$" + withoutDollar.substring(pathStart);
                     Object target = engine.get(varName);
                     if (target != null) {
-                        return JsonPath.read(target, jsonPath);
+                        return JsonPath.using(jsonPathConfig).parse(target).read(jsonPath);
                     }
                     return null;
                 } else if (pathStart == 0) {
                     // $. or $[ means use 'response'
                     Object target = engine.get("response");
                     if (target != null) {
-                        return JsonPath.read(target, "$" + withoutDollar);
+                        return JsonPath.using(jsonPathConfig).parse(target).read("$" + withoutDollar);
                     }
                     return null;
                 }

--- a/karate-core/src/main/java/io/karatelabs/core/KarateJsUtils.java
+++ b/karate-core/src/main/java/io/karatelabs/core/KarateJsUtils.java
@@ -23,6 +23,8 @@
  */
 package io.karatelabs.core;
 
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
 import io.karatelabs.common.DataUtils;
 import io.karatelabs.common.Json;
 import io.karatelabs.common.OsUtils;
@@ -70,6 +72,9 @@ import java.util.regex.Pattern;
 public class KarateJsUtils {
 
     private static final Logger logger = LogContext.RUNTIME_LOGGER;
+
+    private static final Configuration jsonPathConfig = Configuration.defaultConfiguration()
+            .addOptions(Option.SUPPRESS_EXCEPTIONS);
 
     private KarateJsUtils() {
         // utility class
@@ -274,7 +279,7 @@ public class KarateJsUtils {
             }
             Object json = args[0];
             String path = args[1].toString();
-            return JsonPath.read(json, path);
+            return JsonPath.using(jsonPathConfig).parse(json).read(path);
         };
     }
 

--- a/karate-core/src/main/java/io/karatelabs/core/SslUtils.java
+++ b/karate-core/src/main/java/io/karatelabs/core/SslUtils.java
@@ -51,8 +51,11 @@ public class SslUtils {
      */
     public static SSLContext generateSelfSigned() {
         try {
+            java.util.Date notBefore = new java.util.Date();
+            java.util.Date notAfter = new java.util.Date(notBefore.getTime() + (86400000L * VALIDITY_DAYS));
+
             @SuppressWarnings("deprecation")
-            SelfSignedCertificate ssc = SelfSignedCertificate.builder().fqdn("localhost").build();
+            SelfSignedCertificate ssc = new SelfSignedCertificate("localhost", notBefore, notAfter);
 
             // Create KeyStore from the self-signed certificate
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
@@ -88,8 +91,12 @@ public class SslUtils {
      */
     public static SslContext generateNettySslContext() {
         try {
+            java.util.Date notBefore = new java.util.Date();
+            java.util.Date notAfter = new java.util.Date(notBefore.getTime() + (86400000L * VALIDITY_DAYS));
+
             @SuppressWarnings("deprecation")
-            SelfSignedCertificate ssc = SelfSignedCertificate.builder().fqdn("localhost").build();
+            SelfSignedCertificate ssc = new SelfSignedCertificate("localhost", notBefore, notAfter);
+
             return SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
         } catch (Exception e) {
             throw new RuntimeException("failed to generate Netty SSL context: " + e.getMessage(), e);

--- a/karate-core/src/test/java/io/karatelabs/core/StepJsTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/StepJsTest.java
@@ -262,12 +262,34 @@ class StepJsTest {
     }
 
     @Test
+    void testKarateJsonPathWithMissingField() {
+        ScenarioRuntime sr = run("""
+            * def json = [{bar: 1}, {bar: 2}]
+            * def fun = function(arg) { return karate.jsonPath(arg, '$.foo.[*].bar') }
+            * def res = call fun json
+            * match res == []
+            """);
+        assertPassed(sr);
+    }
+
+    @Test
     void testKarateGetWithJsonPath() {
         ScenarioRuntime sr = run("""
             * def foo = { bar: [{baz: 1}, {baz: 2}, {baz: 3}]}
             * def fun = function(){ return karate.get('$foo.bar[*].baz') }
             * def res = call fun
             * match res == [1, 2, 3]
+            """);
+        assertPassed(sr);
+    }
+
+    @Test
+    void testKarateGetMissingFieldWithJsonPath() {
+        ScenarioRuntime sr = run("""
+            * def foo = { x: [{baz: 1}, {baz: 2}, {baz: 3}]}
+            * def fun = function(){ return karate.get('$foo.bar[*].baz') }
+            * def res = call fun
+            * match res == []
             """);
         assertPassed(sr);
     }
@@ -314,6 +336,15 @@ class StepJsTest {
             * def json = { foo: [] }
             * karate.set('json', '$.foo[]', { bar: 'baz' })
             * match json == { foo: [{ bar: 'baz' }] }
+            """);
+        assertPassed(sr);
+    }
+
+    @Test
+    void testKarateSetMissingFieldsWithJsonPath() {
+        ScenarioRuntime sr = run("""
+            * karate.set('json', '$.foo.bar', 'baz')
+            * match json == { foo: { bar: 'baz' } }
             """);
         assertPassed(sr);
     }

--- a/karate-core/src/test/java/io/karatelabs/core/ssl/SslTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/ssl/SslTest.java
@@ -80,8 +80,10 @@ class SslTest {
         ).ssl(true).start();
 
         // Generate server and client certificates for mTLS
-        SelfSignedCertificate serverCert = SelfSignedCertificate.builder().fqdn("localhost").build();
-        SelfSignedCertificate clientCert = SelfSignedCertificate.builder().fqdn("client").build();
+        java.util.Date notBefore = new java.util.Date();
+        java.util.Date notAfter = new java.util.Date(notBefore.getTime() + (86400000L * 365));
+        SelfSignedCertificate serverCert = new SelfSignedCertificate("localhost", notBefore, notAfter);
+        SelfSignedCertificate clientCert = new SelfSignedCertificate("client", notBefore, notAfter);
 
         // Create server SSL context requiring client certificate
         SslContext mtlsSslContext = SslContextBuilder

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.5</version>
                 <configuration>
+                    <systemPropertyVariables>
+                        <user.timezone>UTC</user.timezone>
+                    </systemPropertyVariables>
                     <!-- Exclude testcontainers E2E tests by default (require Docker) -->
                     <excludes>
                         <exclude>**/e2e/**</exclude>


### PR DESCRIPTION
## Description

Ensure `karate.get` and `karate.jsonPath` do not throw when the target variable is missing fields referenced in json path query.

Note: tests we're failing locally prior to this change due to timezone issues. To resolve this I've also added an explicit `UTC` user timezone setting in pom.xml and set explicit `notBefore` and `notAfter` dates in self-signed certs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
