### PR TITLE
fix deadlock when reinitializing a driver after `driver.quit()`

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/KarateJsBase.java
+++ b/karate-core/src/main/java/io/karatelabs/core/KarateJsBase.java
@@ -192,6 +192,7 @@ abstract class KarateJsBase implements SimpleObject {
         data.put("line", s.getLine());
         data.put("sectionIndex", s.getSection().getIndex());
         data.put("exampleIndex", s.getExampleIndex());
+        data.put("runtime", getRuntime());
         Map<String, Object> exampleData = s.getExampleData();
         if (exampleData != null) {
             data.put("exampleData", exampleData);

--- a/karate-core/src/main/java/io/karatelabs/core/ScenarioRuntime.java
+++ b/karate-core/src/main/java/io/karatelabs/core/ScenarioRuntime.java
@@ -1637,6 +1637,7 @@ public class ScenarioRuntime implements Callable<ScenarioResult>, KarateJsContex
      * @throws RuntimeException if driver is not configured
      */
     public Driver getDriver() {
+        if (driver != null && driver.isTerminated()) closeDriver();
         if (driver == null || driver.isTerminated()) {
             driver = initDriver();
         }

--- a/karate-core/src/test/resources/io/karatelabs/driver/features/call-driver.feature
+++ b/karate-core/src/test/resources/io/karatelabs/driver/features/call-driver.feature
@@ -22,3 +22,34 @@ Scenario: called feature propagates driver to caller automatically
 * call read('call-config-inherit.feature')
 * print 'Back in main - driver should be available (propagated from callee)'
 * match driver.title == 'Karate Driver Test'
+
+@lock=*
+Scenario: re-init driver after quit
+# Simulate running tests under multiple different browsers (e.g. grid provider like BrowserStack, Sauce Labs, etc...).
+# For efficiency, we want to:
+#  - start each remote browser session only once and run through all tests
+#  - manually terminate each remote browser session when all tests are complete to free up the grid slot
+* def runTestsWithBrowser =
+"""
+function (cfg, testPaths) {
+  if (!karate.get('driver') || driver.isTerminated()) {
+    karate.configure('driver', cfg)
+    karate.set('driver', karate.scenario.runtime.getDriver())
+  }
+  karate.map(testPaths, (testPath) => {
+    driver.clearCookies()
+    driver.setUrl(serverUrl + '/index.html')
+    karate.call(testPath)
+  })
+  driver.quit()
+}
+"""
+# For simplicity we'll use the current number of parallel threads to ensure we excersize the available driver pool.
+# In a realworld case the list of browser configs would be split into even chunks in a dynamic @setup scenario where
+# the number of chunks matches the number of desired parallel threads / simultaneous grid slots to consume. We'd then
+# process each individual chunk sequentially but all available chunks in parallel.
+* def threadCount = karate.scenario.runtime.getFeatureRuntime().getSuite().threadCount
+* def browserConfigs = karate.repeat(threadCount + 1, () => karate.config.driverConfig)
+* def testPaths = ['call-driver-sub.feature']
+* print 'Main feature - calling sub-features with pre-configured drivers'
+* karate.map(browserConfigs, (cfg) => runTestsWithBrowser(cfg, testPaths))


### PR DESCRIPTION
## Description

This PR fixes a driver pool deadlock when calling `driver.quit()` and reinitializing multiple times in a single scenario. The use case for this would be executing tests on different browsers in succession (e.g. on a grid provider).

I've also added a new `runtime` property to `karate.scenario` to expose the `ScenarioRuntime` in JS to aid in dynamic scenarios.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test -P cicd`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
