### PR TITLE
add out-of-process iframe support to CDP driver

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpDriver.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpDriver.java
@@ -102,6 +102,11 @@ public class CdpDriver implements Driver {
     private Frame currentFrame;
     private final Map<String, Integer> frameContexts = new ConcurrentHashMap<>();
 
+    // OOPIF (Out-of-Process Iframe) tracking
+    private final Map<String, Map<String, Object>> oopifTargets = new ConcurrentHashMap<>();
+    private final Map<String, String> oopifSessions = new ConcurrentHashMap<>();
+    private String pageSessionId; // Tracks the main page's session to switch back
+
     // Tab/target tracking for close() support
     private String currentTargetId;
 
@@ -277,6 +282,16 @@ public class CdpDriver implements Driver {
         cdp.method("Page.enable").send();
         cdp.method("Runtime.enable").send();
         cdp.method("Network.enable").send(); // Required for cookie operations
+
+        // Tell Chrome to auto-attach to isolated cross-origin iframes
+        cdp.method("Target.setAutoAttach")
+                .param("autoAttach", true)
+                .param("waitForDebuggerOnStart", false)
+                .param("flatten", true)
+                .send();
+
+        // Store the main page's session ID so we can switch back to it later
+        this.pageSessionId = cdp.getSessionId();
 
         // Enable lifecycle events (required for Page.lifecycleEvent)
         cdp.method("Page.setLifecycleEventsEnabled")
@@ -483,11 +498,19 @@ public class CdpDriver implements Driver {
         //   appear to work (target activated) but subsequent operations would affect the wrong tab
         //
         cdp.on("Runtime.executionContextCreated", event -> {
-            // Filter by session: only process events from current session
+            // Filter by session: only process events from current session or OOPIF sessions.
+            // OOPIF (out-of-process iframe) targets get their own CDP session via
+            // Target.attachedToTarget. When Runtime.enable is called on that session,
+            // Chrome fires executionContextCreated with the OOPIF's sessionId — not the
+            // parent page's. Without accepting OOPIF sessions here, the main-world context
+            // for the cross-origin frame is never stored and ensureFrameContext() falls back
+            // to Page.createIsolatedWorld, where page-set window variables are invisible.
             String eventSession = event.getSessionId();
             String currentSession = cdp.getSessionId();
-            if (eventSession != null && !eventSession.equals(currentSession)) {
-                logger.trace("ignoring executionContextCreated from old session: {}", eventSession);
+            boolean isCurrentSession = eventSession == null || eventSession.equals(currentSession);
+            boolean isOopifSession = eventSession != null && oopifSessions.containsValue(eventSession);
+            if (!isCurrentSession && !isOopifSession) {
+                logger.trace("ignoring executionContextCreated from unknown session: {}", eventSession);
                 return;
             }
 
@@ -562,6 +585,30 @@ public class CdpDriver implements Driver {
             if (targetId == null) return;
             knownTargetIds.remove(targetId);
             openedTargets.removeIf(entry -> targetId.equals(entry.get("targetId")));
+        });
+
+        // Catch cross-origin iframes as they attach
+        cdp.on("Target.attachedToTarget", event -> {
+            String attachedSessionId = event.get("sessionId");
+            Map<String, Object> targetInfo = event.get("targetInfo");
+
+            if (targetInfo != null && "iframe".equals(targetInfo.get("type"))) {
+                String targetId = (String) targetInfo.get("targetId"); // targetId = frameId
+                oopifTargets.put(targetId, targetInfo);
+                oopifSessions.put(targetId, attachedSessionId);
+                logger.debug("Attached to isolated iframe (OOPIF): {} with session: {}", targetInfo.get("url"), attachedSessionId);
+
+                cdp.method("Runtime.enable").sessionId(attachedSessionId).send();
+                cdp.method("Page.enable").sessionId(attachedSessionId).send();
+            }
+        });
+
+        // Remove tracked sessions when detached
+        cdp.on("Target.detachedFromTarget", event -> {
+            String detachedSessionId = event.get("sessionId");
+            if (detachedSessionId != null) {
+                oopifSessions.values().remove(detachedSessionId);
+            }
         });
 
         // Request interception
@@ -1272,6 +1319,7 @@ public class CdpDriver implements Driver {
         if (locator == null) {
             // Switch back to main frame
             currentFrame = null;
+            cdp.setSessionId(pageSessionId); // Restore main session
             logger.debug("switched to main frame");
             return;
         }
@@ -1306,37 +1354,83 @@ public class CdpDriver implements Driver {
         CdpResponse response = cdp.method("Page.getFrameTree").send();
         List<Map<String, Object>> childFrames = response.getResult("frameTree.childFrames");
 
-        if (childFrames == null || childFrames.isEmpty()) {
-            throw new DriverException("no child frames in page");
-        }
-
         // Find matching frame in tree
         String frameId = null;
         String url = null;
         String name = null;
 
-        for (Map<String, Object> frameData : childFrames) {
-            Map<String, Object> frame = (Map<String, Object>) frameData.get("frame");
-            String fId = (String) frame.get("id");
-            String fUrl = (String) frame.get("url");
-            String fName = (String) frame.get("name");
+        // 1. Try standard, same-origin frames first
+        if (childFrames != null) {
+            for (Map<String, Object> frameData : childFrames) {
+                Map<String, Object> frame = (Map<String, Object>) frameData.get("frame");
+                String fId = (String) frame.get("id");
+                String fUrl = (String) frame.get("url");
+                String fName = (String) frame.get("name");
 
-            // Match by name if provided, otherwise by URL
-            boolean matches = false;
-            if (targetName != null && !targetName.isEmpty() && targetName.equals(fName)) {
-                matches = true;
-            } else if (targetSrc != null && !targetSrc.isEmpty() && fUrl != null && fUrl.contains(targetSrc)) {
-                matches = true;
-            } else if ((targetName == null || targetName.isEmpty()) && (targetSrc == null || targetSrc.isEmpty())) {
-                // No name or src - use first frame
-                matches = true;
+                // Match by name if provided, otherwise by URL
+                boolean matches = false;
+                if (targetName != null && !targetName.isEmpty() && targetName.equals(fName)) {
+                    matches = true;
+                } else if (targetSrc != null && !targetSrc.isEmpty() && fUrl != null && fUrl.contains(targetSrc)) {
+                    matches = true;
+                } else if ((targetName == null || targetName.isEmpty()) && (targetSrc == null || targetSrc.isEmpty())) {
+                    // No name or src - use first frame
+                    matches = true;
+                }
+
+                if (matches) {
+                    frameId = fId;
+                    url = fUrl;
+                    name = fName;
+                    cdp.setSessionId(pageSessionId); // Ensure we are on the main session
+                    break;
+                }
             }
+        }
 
-            if (matches) {
-                frameId = fId;
-                url = fUrl;
-                name = fName;
-                break;
+        // 2. If not found, check isolated OOPIFs
+        if (frameId == null) {
+            for (Map.Entry<String, String> entry : oopifSessions.entrySet()) {
+                String potentialFrameId = entry.getKey();
+                String sessionId = entry.getValue();
+
+                // Switch CDP context into the isolated iframe
+                cdp.setSessionId(sessionId);
+
+                try {
+                    // Ask the iframe what its name and URL are from the inside
+                    CdpResponse evalName = cdp.method("Runtime.evaluate")
+                            .param("expression", "window.name")
+                            .param("returnByValue", true).send();
+                    CdpResponse evalUrl = cdp.method("Runtime.evaluate")
+                            .param("expression", "window.location.href")
+                            .param("returnByValue", true).send();
+
+                    String internalName = evalName.getResultAsString("result.value");
+                    String internalUrl = evalUrl.getResultAsString("result.value");
+
+                    boolean matches = false;
+                    if (targetName != null && !targetName.isEmpty() && targetName.equals(internalName)) {
+                        matches = true;
+                    } else if (targetSrc != null && !targetSrc.isEmpty() && internalUrl != null && internalUrl.contains(targetSrc)) {
+                        matches = true;
+                    } else if ((targetName == null || targetName.isEmpty()) && (targetSrc == null || targetSrc.isEmpty())) {
+                        matches = true;
+                    }
+
+                    if (matches) {
+                        frameId = potentialFrameId;
+                        url = internalUrl;
+                        name = internalName;
+                        // We found our frame. Leave cdp.setSessionId as is to route future commands here.
+                        break;
+                    }
+                } catch (Exception e) {
+                    logger.trace("Failed to query OOPIF internal state: {}", e.getMessage());
+                }
+
+                // If not matched, revert back to the main session to try the next one
+                cdp.setSessionId(pageSessionId);
             }
         }
 
@@ -2734,6 +2828,8 @@ public class CdpDriver implements Driver {
         if (sessionId != null) {
             // Update the CDP client to use this session
             cdp.setSessionId(sessionId);
+            // Sync the new page session
+            this.pageSessionId = sessionId;
         }
 
         // Re-enable required domains on new target (triggers executionContextCreated)

--- a/karate-core/src/test/java/io/karatelabs/driver/e2e/OopifE2eTest.java
+++ b/karate-core/src/test/java/io/karatelabs/driver/e2e/OopifE2eTest.java
@@ -1,0 +1,184 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Karate Labs Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.karatelabs.driver.e2e;
+
+import io.karatelabs.common.FileUtils;
+import io.karatelabs.common.ResourceType;
+import io.karatelabs.core.Runner;
+import io.karatelabs.core.SslUtils;
+import io.karatelabs.core.SuiteResult;
+import io.karatelabs.driver.e2e.support.ChromeContainer;
+import io.karatelabs.driver.e2e.support.ContainerDriverProvider;
+import io.karatelabs.driver.e2e.support.TestPageServer;
+import io.karatelabs.http.HttpResponse;
+import io.karatelabs.http.HttpServer;
+import io.netty.handler.ssl.SslContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * E2E test for out-of-process iframes (OOPIF).
+ *
+ * <p>Chrome isolates cross-origin iframes into separate processes when the parent
+ * and child frames have different sites (scheme + eTLD+1). This test verifies that
+ * the CDP driver can switch into and interact with such frames.</p>
+ *
+ * <h2>Architecture</h2>
+ * <ul>
+ *   <li><b>HTTP server</b> (port {@value HTTP_PORT}): serves the parent page with an iframe element</li>
+ *   <li><b>HTTPS server</b> (port {@value HTTPS_PORT}): serves the iframe content with a self-signed cert</li>
+ * </ul>
+ *
+ * <p>To reliably trigger OOPIF, the two servers use <b>different hostnames</b>:
+ * the parent page is served via {@code host.testcontainers.internal} (testcontainers'
+ * SOCKS proxy) while the iframe is served via {@code host.docker.internal} (Docker's
+ * built-in host mapping). Different hostnames mean different eTLD+1 values, which
+ * combined with different schemes guarantees Chrome places the iframe in a separate
+ * process — exactly like a real third-party iframe (e.g. PayPal).</p>
+ *
+ * <p>The Chrome container is started with {@code --ignore-certificate-errors} (for the
+ * self-signed cert) and {@code --site-per-process} (to enforce process-per-site
+ * isolation in headless mode).</p>
+ *
+ * <p>This test uses its own Chrome container (not SharedChromeContainer) because it
+ * requires custom Chrome flags and a dedicated HTTPS server.</p>
+ */
+@org.testcontainers.junit.jupiter.Testcontainers
+class OopifE2eTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(OopifE2eTest.class);
+
+    private static final int HTTP_PORT = 18082;
+    private static final int HTTPS_PORT = 18083;
+
+    static {
+        System.setProperty("api.version", "1.44");
+        Testcontainers.exposeHostPorts(HTTP_PORT, HTTPS_PORT);
+        logger.info("exposed host ports {} (HTTP) and {} (HTTPS) to containers", HTTP_PORT, HTTPS_PORT);
+    }
+
+    @Container
+    private static final ChromeContainer chrome = createContainer();
+
+    private static TestPageServer httpServer;
+    private static HttpServer httpsServer;
+
+    private static ChromeContainer createContainer() {
+        ChromeContainer c = new ChromeContainer();
+        // --ignore-certificate-errors: accept self-signed cert on the HTTPS server
+        // --site-per-process: force process-per-site isolation in headless mode
+        c.withCommand("--remote-allow-origins=* --ignore-certificate-errors --site-per-process");
+        return c;
+    }
+
+    @BeforeAll
+    static void setup() {
+        httpServer = TestPageServer.start(HTTP_PORT);
+        logger.info("HTTP test server started on port: {}", httpServer.getPort());
+
+        httpsServer = startHttpsServer(HTTPS_PORT);
+        logger.info("HTTPS test server started on port: {}", HTTPS_PORT);
+
+        String serverUrl = chrome.getHostAccessUrl(HTTP_PORT);
+        // Use host.docker.internal (different hostname from host.testcontainers.internal)
+        // so Chrome sees a different eTLD+1 and isolates the iframe into a separate process.
+        // ChromeContainer already maps host.docker.internal via --add-host=host-gateway.
+        String httpsServerUrl = "https://host.docker.internal:" + HTTPS_PORT;
+
+        System.setProperty("karate.driver.serverUrl", serverUrl);
+        System.setProperty("karate.driver.httpsServerUrl", httpsServerUrl);
+        logger.info("serverUrl: {}", serverUrl);
+        logger.info("httpsServerUrl: {}", httpsServerUrl);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (httpServer != null) {
+            httpServer.stopAsync();
+            httpServer = null;
+        }
+        if (httpsServer != null) {
+            httpsServer.stopAsync();
+            httpsServer = null;
+        }
+        System.clearProperty("karate.driver.serverUrl");
+        System.clearProperty("karate.driver.httpsServerUrl");
+    }
+
+    @Test
+    void testOopifFeatures() {
+        ContainerDriverProvider provider = new ContainerDriverProvider(chrome);
+
+        Path reportDir = Path.of("target", "oopif-reports");
+
+        SuiteResult result = Runner.path("classpath:io/karatelabs/driver/oopif")
+                .configDir("classpath:io/karatelabs/driver/oopif/karate-config.js")
+                .outputDir(reportDir)
+                .outputHtmlReport(true)
+                .outputConsoleSummary(true)
+                .driverProvider(provider)
+                .parallel(1);
+
+        logger.info("Feature count: {}", result.getFeatureCount());
+        logger.info("Scenarios passed: {}", result.getScenarioPassedCount());
+        logger.info("Scenarios failed: {}", result.getScenarioFailedCount());
+
+        if (result.isFailed()) {
+            result.getErrors().forEach(error ->
+                logger.error("Test error: {}", error)
+            );
+        }
+
+        assertTrue(result.isPassed(), "All OOPIF feature tests should pass");
+    }
+
+    private static HttpServer startHttpsServer(int port) {
+        SslContext sslContext = SslUtils.generateNettySslContext();
+        byte[] frameHtml = loadClasspathResource("io/karatelabs/driver/pages/oopif-frame.html");
+        return HttpServer.start(port, sslContext, request -> {
+            HttpResponse response = new HttpResponse();
+            response.setBody(frameHtml, ResourceType.HTML);
+            return response;
+        });
+    }
+
+    private static byte[] loadClasspathResource(String path) {
+        InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+        if (is == null) {
+            throw new RuntimeException("classpath resource not found: " + path);
+        }
+        return FileUtils.toBytes(is);
+    }
+
+}

--- a/karate-core/src/test/resources/io/karatelabs/driver/oopif/karate-config.js
+++ b/karate-core/src/test/resources/io/karatelabs/driver/oopif/karate-config.js
@@ -1,0 +1,25 @@
+function fn() {
+  var webSocketUrl = karate.properties['karate.driver.webSocketUrl'];
+  var serverUrl = karate.properties['karate.driver.serverUrl'];
+  var httpsServerUrl = karate.properties['karate.driver.httpsServerUrl'];
+
+  karate.log('karate-config (oopif): serverUrl =', serverUrl);
+  karate.log('karate-config (oopif): httpsServerUrl =', httpsServerUrl);
+
+  var driverConfig = { timeout: 30000 };
+
+  if (webSocketUrl) {
+    driverConfig.webSocketUrl = webSocketUrl;
+    karate.log('karate-config (oopif): webSocketUrl =', webSocketUrl);
+  }
+
+  var config = {
+    serverUrl: serverUrl,
+    httpsServerUrl: httpsServerUrl,
+    driverConfig: driverConfig
+  };
+
+  karate.configure('driver', config.driverConfig);
+
+  return config;
+}

--- a/karate-core/src/test/resources/io/karatelabs/driver/oopif/oopif.feature
+++ b/karate-core/src/test/resources/io/karatelabs/driver/oopif/oopif.feature
@@ -1,0 +1,44 @@
+@lock=oopif
+Feature: Out-of-Process Iframe (OOPIF) Support
+  Cross-origin frame switching where the iframe is served over HTTPS
+  from a different origin than the HTTP parent page, triggering
+  Chrome's out-of-process iframe (OOPIF) behavior.
+
+  Background:
+    * configure driver = driverConfig
+    * driver serverUrl + '/oopif'
+    * switchFrame(null)
+
+  Scenario: Switch to cross-origin HTTPS iframe and back
+    # Verify parent page content
+    * def title = text('h1')
+    * match title == 'OOPIF Parent Page'
+    # Load cross-origin iframe from HTTPS server
+    * script("document.getElementById('cross-origin-frame').src = '" + httpsServerUrl + "/oopif-frame'")
+    * delay(1000)
+    # Switch to the cross-origin iframe
+    * switchFrame('#cross-origin-frame')
+    * def heading = text('h2')
+    * match heading == 'OOPIF Frame Content'
+    # Switch back to parent frame
+    * switchFrame(null)
+    * def parentTitle = text('h1')
+    * match parentTitle == 'OOPIF Parent Page'
+
+  Scenario: Read element text inside cross-origin iframe
+    * script("document.getElementById('cross-origin-frame').src = '" + httpsServerUrl + "/oopif-frame'")
+    * delay(1000)
+    * switchFrame('#cross-origin-frame')
+    * def frameText = text('#frame-text')
+    * match frameText == 'This content is inside the cross-origin iframe.'
+    * switchFrame(null)
+
+  Scenario: Execute script inside cross-origin iframe
+    * script("document.getElementById('cross-origin-frame').src = '" + httpsServerUrl + "/oopif-frame'")
+    * delay(1000)
+    * switchFrame('#cross-origin-frame')
+    * def value = script('window.frameValue')
+    * match value == 'oopif-frame-data'
+    * switchFrame(null)
+    * def parentValue = script('window.parentValue')
+    * match parentValue == 'parent-data'

--- a/karate-core/src/test/resources/io/karatelabs/driver/pages/oopif-frame.html
+++ b/karate-core/src/test/resources/io/karatelabs/driver/pages/oopif-frame.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OOPIF Frame</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            padding: 20px;
+            background: #e8f5e9;
+        }
+    </style>
+</head>
+<body>
+    <h2>OOPIF Frame Content</h2>
+    <p id="frame-text">This content is inside the cross-origin iframe.</p>
+
+    <script>
+        console.log('OOPIF frame loaded');
+        window.frameValue = 'oopif-frame-data';
+    </script>
+</body>
+</html>

--- a/karate-core/src/test/resources/io/karatelabs/driver/pages/oopif.html
+++ b/karate-core/src/test/resources/io/karatelabs/driver/pages/oopif.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OOPIF Test</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        h1 { color: #333; }
+        .frame-container {
+            margin: 20px 0;
+            border: 2px solid #ccc;
+            border-radius: 4px;
+        }
+        iframe {
+            width: 100%;
+            height: 300px;
+            border: none;
+        }
+    </style>
+</head>
+<body>
+    <h1>OOPIF Parent Page</h1>
+    <p id="main-text">This page hosts a cross-origin iframe (OOPIF).</p>
+
+    <div class="frame-container">
+        <iframe id="cross-origin-frame" name="crossOriginFrame"></iframe>
+    </div>
+
+    <script>
+        console.log('OOPIF parent page loaded');
+        window.parentValue = 'parent-data';
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Description

Add support for out-of-process iframes in CDP driver. An example use case would be filling out Stripe / PayPal credit card fields.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
