### PR TITLE
add support for line filters in `karate.call`

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/FeatureRuntime.java
+++ b/karate-core/src/main/java/io/karatelabs/core/FeatureRuntime.java
@@ -71,6 +71,7 @@ public class FeatureRuntime implements Callable<FeatureResult> {
     private FeatureResult result;
     private final Map<Integer, Integer> outlineCompletedCounts = new HashMap<>();  // section index -> completed count
     private int loopIndex = -1;  // -1 means not a loop call; 0+ is the iteration index
+    private final Set<Integer> lineFilters;
 
     public FeatureRuntime(Feature feature) {
         this(null, feature, null, null, false, null);
@@ -89,6 +90,10 @@ public class FeatureRuntime implements Callable<FeatureResult> {
     }
 
     public FeatureRuntime(Suite suite, Feature feature, FeatureRuntime caller, ScenarioRuntime callerScenario, boolean sharedScope, Map<String, Object> callArg, String callTagSelector) {
+        this(suite, feature, caller, callerScenario, sharedScope, callArg, callTagSelector, null);
+    }
+
+    public FeatureRuntime(Suite suite, Feature feature, FeatureRuntime caller, ScenarioRuntime callerScenario, boolean sharedScope, Map<String, Object> callArg, String callTagSelector, Set<Integer> lineFilters) {
         this.suite = suite;
         this.feature = feature;
         this.caller = caller;
@@ -98,6 +103,7 @@ public class FeatureRuntime implements Callable<FeatureResult> {
         this.callTagSelector = callTagSelector;
         this.result = new FeatureResult(feature);
         this.result.setCallDepth(getCallDepth());
+        this.lineFilters = lineFilters;
     }
 
     public int getCallDepth() {
@@ -675,21 +681,24 @@ public class FeatureRuntime implements Callable<FeatureResult> {
         private boolean shouldSelect(Scenario scenario) {
             // Check line filter first (if specified)
             // Line filter takes precedence for scenario selection
-            if (suite != null && !suite.lineFilters.isEmpty()) {
+            Set<Integer> lines = null;
+            if (lineFilters != null && !lineFilters.isEmpty()) {
+                lines = lineFilters;
+            } else if (suite != null && !suite.lineFilters.isEmpty() && caller == null) {
                 String featureUri = feature.getResource().getUri().toString();
-                Set<Integer> lines = suite.lineFilters.get(featureUri);
-                if (lines != null && !lines.isEmpty()) {
-                    // Line filter is specified for this feature
-                    if (!matchesLineFilter(scenario, lines)) {
-                        return false;
-                    }
-                    // Line filter matched — if a scenario name is also set,
-                    // intersect (both must match). Otherwise skip other filters.
-                    if (suite.scenarioName != null && !matchesScenarioName(scenario)) {
-                        return false;
-                    }
-                    return true;
+                lines = suite.lineFilters.get(featureUri);
+            }
+            if (lines != null && !lines.isEmpty()) {
+                // Line filter is specified for this feature
+                if (!matchesLineFilter(scenario, lines)) {
+                    return false;
                 }
+                // Line filter matched — if a scenario name is also set,
+                // intersect (both must match). Otherwise skip other filters.
+                if (suite.scenarioName != null && !matchesScenarioName(scenario)) {
+                    return false;
+                }
+                return true;
             }
 
             // Apply call-level tag filter if specified (takes precedence)

--- a/karate-core/src/main/java/io/karatelabs/core/KarateJs.java
+++ b/karate-core/src/main/java/io/karatelabs/core/KarateJs.java
@@ -1303,6 +1303,7 @@ public class KarateJs extends KarateJsBase implements PerfContext {
             case "remove" -> remove();
             case "render" -> render();
             case "request" -> getRequest();
+            case "resolveScenarios" -> resolveScenarios();
             case "response" -> getResponse();
             case "scenario" -> getScenarioData();
             case "scenarioOutline" -> getScenarioOutlineData();

--- a/karate-core/src/main/java/io/karatelabs/core/KarateJsBase.java
+++ b/karate-core/src/main/java/io/karatelabs/core/KarateJsBase.java
@@ -424,6 +424,62 @@ abstract class KarateJsBase implements SimpleObject {
     }
 
     /**
+     * karate.resolveScenarios() - Resolve all scenarios matching criteria.
+     */
+    JavaInvokable resolveScenarios() {
+        return args -> {
+            ScenarioRuntime rt = getRuntime();
+            if (rt == null) {
+                throw new RuntimeException("karate.resolveScenarios() is not available in this context");
+            }
+
+            if (args.length < 1) {
+                throw new RuntimeException("resolveScenarios() needs at least one argument");
+            }
+
+            if (!(args[0] instanceof Map options)) {
+                throw new RuntimeException("invalid resolveScenarios options: expected map");
+            }
+
+            String[] paths;
+            Object pathsRaw = options.get("path");
+            if (pathsRaw == null) {
+                paths = new String[]{""};
+            } else if (pathsRaw instanceof List) {
+                List pathsList = (List) pathsRaw;
+                paths = new String[pathsList.size()];
+                for (int i = 0; i < pathsList.size(); i++) {
+                    paths[i] = pathsList.get(i).toString();
+                }
+            } else {
+                paths = new String[]{pathsRaw.toString()};
+            }
+
+            String[] tags = null;
+            Object tagsRaw = options.get("tags");
+            if (tagsRaw != null) {
+                if (tagsRaw instanceof List) {
+                    List tagsList = (List) tagsRaw;
+                    tags = new String[tagsList.size()];
+                    for (int i = 0; i < tagsList.size(); i++) {
+                        tags[i] = tagsList.get(i).toString();
+                    }
+                } else {
+                    tags = new String[]{tagsRaw.toString()};
+                }
+            }
+
+            Object workingDirRaw = options.get("workingDir");
+            String workingDir = workingDirRaw != null ? workingDirRaw.toString() : null;
+
+            Object envRaw = options.get("env");
+            String env = envRaw != null ? envRaw.toString() : null;
+
+            return rt.getScenarioPathsFor(workingDir, paths, tags, env);
+        };
+    }
+
+    /**
      * Returns system properties available via karate.properties['key'].
      */
     Map<String, String> getProperties() {

--- a/karate-core/src/main/java/io/karatelabs/core/Runner.java
+++ b/karate-core/src/main/java/io/karatelabs/core/Runner.java
@@ -821,7 +821,15 @@ public final class Runner {
                 }
             }
 
+
             File file = new File(actualPath);
+            if (!file.toPath().startsWith(root)) {
+                Path relativePath = file.toPath();
+                if (relativePath.isAbsolute()) {
+                    relativePath = relativePath.getRoot().relativize(relativePath);
+                }
+                file = root.resolve(relativePath).toFile();
+            }
 
             if (file.isDirectory()) {
                 resolveDirectory(file, target, root);

--- a/karate-core/src/main/java/io/karatelabs/core/ScenarioRuntime.java
+++ b/karate-core/src/main/java/io/karatelabs/core/ScenarioRuntime.java
@@ -31,6 +31,7 @@ import io.karatelabs.driver.cdp.CdpDriver;
 import io.karatelabs.driver.cdp.CdpDriverOptions;
 import io.karatelabs.driver.DriverApi;
 import io.karatelabs.gherkin.Feature;
+import io.karatelabs.gherkin.FeatureSection;
 import io.karatelabs.gherkin.Scenario;
 import io.karatelabs.gherkin.Step;
 import io.karatelabs.gherkin.Tag;
@@ -42,11 +43,15 @@ import org.slf4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -398,6 +403,7 @@ public class ScenarioRuntime implements Callable<ScenarioResult>, KarateJsContex
         // Parse path and tag selector
         String tagSelector;
         Feature calledFeature;
+        Set<Integer> lineFilters = null;
 
         if (path.startsWith("@")) {
             // Same-file tag call: call('@tagname')
@@ -414,13 +420,35 @@ public class ScenarioRuntime implements Callable<ScenarioResult>, KarateJsContex
                 featurePath = path;
                 tagSelector = null;
             }
+
+            if (featurePath.contains(".feature:")) {
+                int featureExtIndex = path.indexOf(".feature:");
+                int colonIndex = featureExtIndex + ".feature".length();
+                String potentialPath = path.substring(0, colonIndex);
+                String remainder = path.substring(colonIndex + 1);
+
+                if (remainder.matches("\\d+(:\\d+)*")) {
+                    featurePath = potentialPath;
+                    lineFilters = new HashSet<>();
+                    for (String lineStr : remainder.split(":")) {
+                        try {
+                            lineFilters.add(Integer.parseInt(lineStr));
+                        } catch (NumberFormatException e) {
+                            featurePath = path;
+                            lineFilters.clear();
+                            break;
+                        }
+                    }
+                }
+            }
+
             Resource calledResource = featureRuntime.resolve(featurePath);
             calledFeature = Feature.read(calledResource);
         }
 
         // Array-loop call - delegate to shared helper used by the `call` keyword
         if (arg instanceof List) {
-            return executor.callFeatureLoop(calledFeature, (List<?>) arg, tagSelector);
+            return executor.callFeatureLoop(calledFeature, (List<?>) arg, tagSelector, lineFilters);
         }
 
         // Single call - arg must be a map (or null)
@@ -433,7 +461,7 @@ public class ScenarioRuntime implements Callable<ScenarioResult>, KarateJsContex
             }
         }
 
-        Map<String, Object> resultVars = executor.callFeatureSingle(calledFeature, callArg, tagSelector);
+        Map<String, Object> resultVars = executor.callFeatureSingle(calledFeature, callArg, tagSelector, lineFilters);
         return resultVars != null ? resultVars : new HashMap<>();
     }
 
@@ -2067,6 +2095,37 @@ public class ScenarioRuntime implements Callable<ScenarioResult>, KarateJsContex
         if (hook != null) {
             hook.reportPerfEvent(event);
         }
+    }
+
+    protected List<String> getScenarioPathsFor(String workingDirPath, String[] featurePaths, String[] tags, String env) {
+        Path workingDir = workingDirPath == null || workingDirPath.isEmpty()
+                ? featureRuntime.resolve("/").getPath()
+                : new File(workingDirPath).toPath();
+        List<Feature> features = Runner.builder().workingDir(workingDir).path(featurePaths).tags(tags).getResolvedFeatures();
+        if (features == null) {
+            return Collections.emptyList();
+        }
+
+        Map<String,Boolean> scenarioPaths = new LinkedHashMap<>();
+        String tagFilter = TagSelector.fromKarateOptionsTags(tags);
+
+        for (Feature feature : features) {
+            List<FeatureSection> sections = feature.getSections();
+            if (sections == null) {
+                continue;
+            }
+
+            for (FeatureSection section : sections) {
+                TagSelector selector = new TagSelector(
+                        section.isOutline() ? section.getScenarioOutline().getTags() : section.getScenario().getTags());
+
+                if (selector.evaluate(tagFilter, env)) {
+                    scenarioPaths.put(feature.getResource().getPrefixedPath() + ":" + section.getLine(), Boolean.TRUE);
+                }
+            }
+        }
+
+        return scenarioPaths.keySet().stream().toList();
     }
 
 }

--- a/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
+++ b/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
@@ -59,6 +59,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class StepExecutor {
 
@@ -416,12 +417,12 @@ public class StepExecutor {
 
         // Check if it's an array loop call
         if (call.argList != null) {
-            runtime.setVariable(resultVar, callFeatureLoop(calledFeature, call.argList, call.tagSelector));
+            runtime.setVariable(resultVar, callFeatureLoop(calledFeature, call.argList, call.tagSelector, null));
             return;
         }
 
         // Single call
-        Map<String, Object> resultVars = callFeatureSingle(calledFeature, call.arg, call.tagSelector);
+        Map<String, Object> resultVars = callFeatureSingle(calledFeature, call.arg, call.tagSelector, null);
         if (resultVars != null) {
             runtime.setVariable(resultVar, resultVars);
         }
@@ -477,7 +478,7 @@ public class StepExecutor {
      * keyword paths and the `karate.call()` JS API. Returns the last scenario's
      * variables, or null if no scenario was executed. Throws on called-feature failure.
      */
-    Map<String, Object> callFeatureSingle(Feature calledFeature, Map<String, Object> callArg, String tagSelector) {
+    Map<String, Object> callFeatureSingle(Feature calledFeature, Map<String, Object> callArg, String tagSelector, Set<Integer> lineFilters) {
         FeatureRuntime fr = runtime.getFeatureRuntime();
         FeatureRuntime nestedFr = new FeatureRuntime(
                 fr != null ? fr.getSuite() : null,
@@ -486,7 +487,8 @@ public class StepExecutor {
                 runtime,
                 false,  // Isolated scope - copy variables, don't share
                 callArg,
-                tagSelector
+                tagSelector,
+                lineFilters
         );
         FeatureResult featureResult = nestedFr.call();
         addCallResult(featureResult);
@@ -502,7 +504,7 @@ public class StepExecutor {
      * `call` / `callonce` keyword paths and the `karate.call()` JS API.
      */
     @SuppressWarnings("unchecked")
-    List<Map<String, Object>> callFeatureLoop(Feature calledFeature, List<?> argList, String tagSelector) {
+    List<Map<String, Object>> callFeatureLoop(Feature calledFeature, List<?> argList, String tagSelector, Set<Integer> lineFilters) {
         FeatureRuntime fr = runtime.getFeatureRuntime();
         List<Map<String, Object>> results = new ArrayList<>();
         int loopIndex = 0;
@@ -515,7 +517,8 @@ public class StepExecutor {
                     runtime,
                     false,  // Always isolated scope for array loop
                     callArg,
-                    tagSelector
+                    tagSelector,
+                    lineFilters
             );
             nestedFr.setLoopIndex(loopIndex);
 
@@ -2462,7 +2465,7 @@ public class StepExecutor {
 
         // Check if it's an array loop call
         if (call.argList != null) {
-            List<Map<String, Object>> results = callFeatureLoop(calledFeature, call.argList, call.tagSelector);
+            List<Map<String, Object>> results = callFeatureLoop(calledFeature, call.argList, call.tagSelector, null);
             if (call.resultVar != null) {
                 runtime.setVariable(call.resultVar, results);
             }
@@ -2531,7 +2534,7 @@ public class StepExecutor {
 
         // Check if it's an array loop call
         if (argObj instanceof List) {
-            List<Map<String, Object>> results = callFeatureLoop(calledFeature, (List<?>) argObj, tagSelector);
+            List<Map<String, Object>> results = callFeatureLoop(calledFeature, (List<?>) argObj, tagSelector, null);
             if (resultVar != null) {
                 runtime.setVariable(resultVar, results);
             }

--- a/karate-core/src/test/java/io/karatelabs/core/RunnerTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/RunnerTest.java
@@ -707,4 +707,29 @@ class RunnerTest {
         assertEquals(1, result.getScenarioPassedCount());
     }
 
+    @Test
+    void testRunnerWithScenarioLineFilterAndCallToSelf() throws Exception {
+        Path feature = tempDir.resolve("line-and-call-to-self.feature");
+        Files.writeString(feature, """
+            Feature: Line and call to self
+            @ignore @worker
+            Scenario: Callee
+            * def x = 1
+
+            Scenario: Caller
+            * def result = karate.call('@worker')
+            * match result.x == 1
+            """);
+
+        // :LINE narrows to one of the two duplicate "Same name" scenarios.
+        // Intersection semantics: both filters must match.
+        SuiteResult result = Runner.path(feature+ ":6")
+                .workingDir(tempDir)
+                .outputDir(tempDir.resolve("reports"))
+                .outputConsoleSummary(false)
+                .parallel(1);
+
+        assertTrue(result.isPassed());
+    }
+
 }

--- a/karate-core/src/test/java/io/karatelabs/core/StepCallTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/StepCallTest.java
@@ -1616,4 +1616,39 @@ class StepCallTest {
         assertFalse(result.isPassed(), "Parent should fail when karate.callonce()ed feature fails");
     }
 
+    @Test
+    void testKarateCallWithLineFilter() throws Exception {
+        Path child = tempDir.resolve("child.feature");
+        Files.writeString(child, """
+            Feature: child
+            Scenario: a
+            * def val = 1
+            @b
+            Scenario: b
+            * def val = 2
+            @c
+            Scenario: c
+            * def val = 3
+            """);
+
+        Path parent = tempDir.resolve("parent.feature");
+        Files.writeString(parent, """
+            Feature: parent
+            Scenario:
+            * def result = karate.call('child.feature')
+            * match result.val == 3
+            # hard-coded line number
+            * def result = karate.call('child.feature:2')
+            * match result.val == 1
+            # resolve full path at runtime (preferred over hard-coding line numbers)
+            * def resolvedScenarios = karate.resolveScenarios({ path: 'child.feature', tags: '@b' })
+            * match resolvedScenarios == '#[1]'
+            * def result = karate.call(resolvedScenarios[0])
+            * match result.val == 2
+            """);
+
+        SuiteResult result = runTestSuite(tempDir, parent.toString());
+        assertTrue(result.isPassed(), "Call with line filter should pass: " + getFailureMessage(result));
+    }
+
 }

--- a/karate-core/src/test/java/io/karatelabs/core/StepResolveTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/StepResolveTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Karate Labs Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.karatelabs.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static io.karatelabs.core.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for feature resolution execution.
+ */
+class StepResolveTest {
+
+    @TempDir
+    Path tempDir;
+
+    private String getFailureMessage(SuiteResult result) {
+        if (result.isPassed()) return "none";
+        for (FeatureResult fr : result.getFeatureResults()) {
+            for (ScenarioResult sr : fr.getScenarioResults()) {
+                if (sr.isFailed()) {
+                    return sr.getFailureMessage();
+                }
+            }
+        }
+        return "unknown";
+    }
+
+    @Test
+    void testCallFeatureWithResult() throws Exception {
+        // Create sample features
+        Files.writeString(tempDir.resolve("a.feature"), """
+            Feature:
+            @env=dev,test @high @fast
+            Scenario: explicit lower env only
+            * def result = 1
+            @envnot=prod @fast
+            Scenario: implicit lower env only
+            * def result = 2
+            """);
+
+        Files.createDirectory(tempDir.resolve("sub"));
+        Files.writeString(tempDir.resolve("sub/b.feature"), """
+            Feature:
+            @smoke
+            Scenario: smoke test
+            * def result = 3
+            Scenario: no tags
+            * def result = 4
+            """);
+
+        // Create caller feature
+        Path callerFeature = tempDir.resolve("caller.feature");
+        Files.writeString(callerFeature, """
+            Feature: Caller Feature
+            Scenario: resolve scenarios
+            * def testEnv = karate.resolveScenarios({ env: 'test' })
+            * match testEnv contains ['a.feature:3', 'a.feature:6']
+
+            * def prodEnv = karate.resolveScenarios({ env: 'prod' })
+            * match prodEnv !contains 'a.feature:6'
+
+            * def onlySmoke = karate.resolveScenarios({ tags: '@smoke' })
+            * match onlySmoke contains only 'sub/b.feature:3'
+
+            * def withoutSmoke = karate.resolveScenarios({ tags: '~@smoke' })
+            * match withoutSmoke !contains 'sub/b.feature:3'
+
+            * def multiTag = karate.resolveScenarios({ tags: ['@high', '@fast'], env: 'dev' })
+            * match multiTag contains only 'a.feature:3'
+
+            * def withPath = karate.resolveScenarios({ path: 'sub', tags: '~@smoke' })
+            * match withPath contains only 'sub/b.feature:5'
+            
+            * def multiPath = karate.resolveScenarios({ path: ['a.feature', 'sub/b.feature'] })
+            * match multiPath contains ['a.feature:6', 'sub/b.feature:3']
+            
+            * def withWorkingDir = karate.resolveScenarios({ workingDir: '${root}', tags: '@smoke' })
+            * match withWorkingDir contains only 'sub/b.feature:3'
+            """.replace("${root}", tempDir.toString()));
+
+        SuiteResult result = runTestSuite(tempDir, callerFeature.toString());
+        assertTrue(result.isPassed(), "Suite should pass: " + getFailureMessage(result));
+    }
+
+}


### PR DESCRIPTION
## Description

This PR adds support for line filters in `karate.call`.

As part of this fix, we also fix a related bug where running a test suite with a line filter would artificially limit any called features that intersect with the main feature being limited by the suite line filter (i.e. it would refuse to call a scenario on the same feature outside of the line filter).

Lastly, to aid in the dynamic calling of specific scenarios (i.e. not just features) we add a new `karate.resolveScenarios` method that resolves individual scenarios at runtime. This is useful for granular test filtering as well as granular retry (e.g. in long-running, sometimes flaky tests like external grids where a single failure could be very costly).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
