### PR TITLE
add support for anchor tag with no attributes and exact tag with no text or index in js wildcard locators

### DIFF
--- a/karate-core/src/main/resources/io/karatelabs/driver/driver.js
+++ b/karate-core/src/main/resources/io/karatelabs/driver/driver.js
@@ -233,7 +233,7 @@
         if (!tag || tag === '*') return '*';
         var map = {
             'button': 'button, [role="button"], input[type="submit"], input[type="button"]',
-            'a': 'a[href], [role="link"]',
+            'a': 'a, a[href], [role="link"]',
             'select': 'select, [role="combobox"], [role="listbox"]',
             'input': 'input:not([type="hidden"]), textarea, [role="textbox"]'
         };
@@ -254,6 +254,11 @@
         for (var i = 0; i < candidates.length; i++) {
             var el = candidates[i];
             if (!this.isVisible(el)) continue;
+            if (text === '') {
+                count++;
+                if (count === index) return el;
+                continue;
+            }
             var elText = this.getVisibleText(el);
             if (!elText) continue;
             var matches = contains

--- a/karate-core/src/test/java/io/karatelabs/driver/e2e/LocatorsE2eTest.java
+++ b/karate-core/src/test/java/io/karatelabs/driver/e2e/LocatorsE2eTest.java
@@ -125,6 +125,16 @@ class LocatorsE2eTest extends DriverTestBase {
         assertTrue(driver.exists("{button}Submit"));
     }
 
+    @Test
+    void testWildcardTagOnly() {
+        assertTrue(driver.exists("{details}"));
+    }
+
+    @Test
+    void testWildcardAnchorTagNoAttributes() {
+        assertTrue(driver.exists("{a}Anchor With No Attributes"));
+    }
+
     // ========== Wildcard Contains Match ==========
 
     @Test

--- a/karate-core/src/test/resources/io/karatelabs/driver/pages/locators.html
+++ b/karate-core/src/test/resources/io/karatelabs/driver/pages/locators.html
@@ -160,6 +160,13 @@ Line 2</pre>
         <label for="agree-checkbox">I agree to terms</label>
     </section>
 
+    <!-- Unique elements to select by anchor with no attributes and element with no text or index -->
+    <section>
+        <h2>Anchor with no attributes and unique element with no text or index</h2>
+        <a>Anchor With No Attributes</a>
+        <details>Sample details</details>
+    </section>
+
     <script>
         console.log('Locators test page loaded');
 


### PR DESCRIPTION
## Description

Restore v1 behavior of wildcard locators for:

- anchor tag with no attributes: `<a>Hello</a>` => `{a}Hello`
- tag with no index or text: `<details>Sample</details>` => `{details}`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
