### PR TITLE
support csv from byte[]

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
+++ b/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
@@ -52,6 +52,7 @@ import com.jayway.jsonpath.JsonPath;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -1056,7 +1057,11 @@ public class StepExecutor {
             // Expression: csv data = someVar
             String expr = text.substring(eqIndex + 1).trim();
             Object value = runtime.eval(expr);
-            csvText = value.toString();
+            if (value instanceof byte[]) {
+                csvText = new String((byte[]) value, StandardCharsets.UTF_8);
+            } else {
+                csvText = value.toString();
+            }
         }
         List<Map<String, Object>> result = DataUtils.fromCsv(csvText);
         runtime.setVariable(name, result);

--- a/karate-core/src/test/java/io/karatelabs/core/StepDataTypesTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/StepDataTypesTest.java
@@ -441,6 +441,17 @@ class StepDataTypesTest {
     }
 
     @Test
+    void testCsvKeywordWithByteArray() {
+        // csv keyword with byte array reference
+        ScenarioRuntime sr = run("""
+            * def csvBytes = "name,age\\nJane,29".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            * csv info = csvBytes
+            * match info == [{ name: 'Jane', age: '29' }]
+            """);
+        assertPassed(sr);
+    }
+
+    @Test
     void testYamlKeywordWithDocString() {
         // yaml keyword with doc string
         ScenarioRuntime sr = run("""


### PR DESCRIPTION
## Description

Restore v1 behavior for parsing csv data from a byte array.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
