### PR TITLE
ensure method is set before processing request when using `configure headers`

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
+++ b/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
@@ -1970,6 +1970,7 @@ public class StepExecutor {
         // Apply configured headers - may be a Map or a JsCallable
         Object configHeaders = config.getHeaders();
         if (configHeaders instanceof JavaCallable headersFn) {
+            http().method(method);
             // Build request first so function can access current state (for signing etc.)
             HttpRequest request = http().build();
             Object result = headersFn.call(null, request);

--- a/karate-core/src/test/java/io/karatelabs/core/StepConfigureTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/StepConfigureTest.java
@@ -23,12 +23,15 @@
  */
 package io.karatelabs.core;
 
+import io.karatelabs.http.HttpResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -591,4 +594,38 @@ class StepConfigureTest {
         assertEquals("new-value", seenOther.get(2));
     }
 
+    @Test
+    void testConfigureHeadersMaintainsMethod() throws Exception {
+        InMemoryHttpClient.Factory factory = new InMemoryHttpClient.Factory(req -> {
+            HttpResponse response = new HttpResponse();
+            if (!Arrays.equals("name=Alex".getBytes(StandardCharsets.UTF_8), req.getBody())) {
+                response.setStatus(400);
+            } else {
+                response.setStatus(200);
+            }
+            return response;
+        });
+
+        Path feature = tempDir.resolve("feature.feature");
+        Files.writeString(feature, """
+                Feature:
+                Scenario:
+                * configure headers = () => ({ 'X-Custom': 'abc123' })
+                * url 'http://test'
+                * form fields { name: "Alex" }
+                * method post
+                * status 200
+                """);
+
+        SuiteResult result = Runner.builder()
+                .path(feature.toString())
+                .workingDir(tempDir)
+                .httpClientFactory(factory)
+                .outputConsoleSummary(false)
+                .outputHtmlReport(false)
+                .backupOutputDir(false)
+                .parallel(1);
+
+        assertTrue(result.isPassed(), "suite should pass");
+    }
 }


### PR DESCRIPTION
## Description

When using `configure header`, request body for PUT / POST was silently converted to query string params during request processing because the method wasn't set at the time of processing.

## Related Issues

https://github.com/karatelabs/karate/issues/2851

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
