### PR TITLE
restore v1 cookie behavior when no url or domain is set

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpDriver.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpDriver.java
@@ -2404,6 +2404,12 @@ public class CdpDriver implements Driver {
     public void cookie(Map<String, Object> cookie) {
         logger.debug("set cookie: {}", cookie.get("name"));
         CdpMessage message = cdp.method("Network.setCookie");
+
+        // CDP requires either a url or a domain. If neither is provided, default to current URL
+        if (!cookie.containsKey("url") && !cookie.containsKey("domain")) {
+            message.param("url", getUrl());
+        }
+
         cookie.forEach(message::param);
         message.send();
     }

--- a/karate-core/src/test/java/io/karatelabs/driver/e2e/CookieE2eTest.java
+++ b/karate-core/src/test/java/io/karatelabs/driver/e2e/CookieE2eTest.java
@@ -60,6 +60,19 @@ class CookieE2eTest extends DriverTestBase {
     }
 
     @Test
+    void testSetAndGetCookieNoDomain() {
+        driver.cookie(Map.of(
+                "name", "test_cookie",
+                "value", "hello123"
+        ));
+
+        Map<String, Object> cookie = driver.cookie("test_cookie");
+        assertNotNull(cookie);
+        assertEquals("test_cookie", cookie.get("name"));
+        assertEquals("hello123", cookie.get("value"));
+    }
+
+    @Test
     void testGetAllCookies() {
         driver.cookie(Map.of(
                 "name", "cookie1",


### PR DESCRIPTION
## Description

Restore parity with v1 cookie set behavior when no url or domain is set (i.e. fallback to current url). This turns out to be very handy when the URL changes between environments and saves manually setting it in multiple locations.

## Related Issues

https://github.com/karatelabs/karate/issues/2851

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
