### PR TITLE
ensure mouse event is actually dispatched on construction

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/driver/Driver.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/Driver.java
@@ -140,8 +140,12 @@ public interface Driver extends CoreDriver, SimpleObject {
                     exists(String.valueOf(args[0]));
             case DriverApi.ENABLED -> (JavaCallable) (ctx, args) ->
                     enabled(String.valueOf(args[0]));
-            case DriverApi.POSITION -> (JavaCallable) (ctx, args) ->
-                    position(String.valueOf(args[0]));
+            case DriverApi.POSITION -> (JavaCallable) (ctx, args) -> {
+                if (args.length > 1 && args[1] instanceof Boolean) {
+                    return position(String.valueOf(args[0]), (Boolean) args[1]);
+                }
+                return position(String.valueOf(args[0]));
+            };
 
             // Locators
             case DriverApi.LOCATE -> (JavaCallable) (ctx, args) ->

--- a/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpMouse.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpMouse.java
@@ -42,15 +42,14 @@ public class CdpMouse implements Mouse {
     private double y;
 
     public CdpMouse(CdpClient cdp) {
-        this.cdp = cdp;
-        this.x = 0;
-        this.y = 0;
+        this(cdp, 0, 0);
     }
 
     public CdpMouse(CdpClient cdp, double x, double y) {
         this.cdp = cdp;
         this.x = x;
         this.y = y;
+        dispatchEvent("mouseMoved");
     }
 
     @Override

--- a/karate-core/src/test/resources/io/karatelabs/driver/features/mouse.feature
+++ b/karate-core/src/test/resources/io/karatelabs/driver/features/mouse.feature
@@ -17,6 +17,10 @@ Feature: Mouse Tests
     * match m.getY() == 200.0
 
   Scenario: Mouse at element
+    # Scrool to element so it is in the viewport
+    * scroll('#submit-btn')
+    # Ensure element does NOT have hover state at start
+    * assert script('#submit-btn', '(b) => getComputedStyle(b).backgroundColor != "rgb(0, 82, 163)"')
     * def m = mouse('#submit-btn')
     * def pos = position('#submit-btn', true)
     * def expectedX = pos.x + pos.width / 2
@@ -26,6 +30,8 @@ Feature: Mouse Tests
     * def yDiff = m.getY() - expectedY
     * assert Math.abs(xDiff) < 2
     * assert Math.abs(yDiff) < 2
+    # Ensure element has hover state - i.e. don't trust mouse impl to self report x,y
+    * assert script('#submit-btn', '(b) => getComputedStyle(b).backgroundColor === "rgb(0, 82, 163)"')
 
   Scenario: Mouse move
     * def m = mouse()


### PR DESCRIPTION
## Description

Fix faulty mouse test and two related bugs:

1. mouse internal state was updated but the browser event wasn't actually triggered when using constructor alone
2. it wasn't possible to set the relative flag on the `position` action (the flag was discarded and always forced absolute)

## Related Issues

https://github.com/karatelabs/karate/issues/2851

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
