### PR TITLE
fix issues with selenium grid server communication and safari inputs

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/driver/Locators.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/Locators.java
@@ -423,8 +423,12 @@ public class Locators {
     public static String inputJs(String locator, String value) {
         String escapedValue = escapeForJs(value);
         String js = "var e = " + selector(locator) + ";" +
+                " if (!e) return;" +
                 " e.focus();" +
-                " e.value = \"" + escapedValue + "\";" +
+                " var proto = e.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;" +
+                " var setter = Object.getOwnPropertyDescriptor(proto, 'value');" +
+                " if (setter && setter.set) { setter.set.call(e, \"" + escapedValue + "\"); }" +
+                " else { e.value = \"" + escapedValue + "\"; }" +
                 " e.dispatchEvent(new Event('input', { bubbles: true }));" +
                 " e.dispatchEvent(new Event('change', { bubbles: true }))";
         return wrapInFunctionInvoke(js);
@@ -435,8 +439,12 @@ public class Locators {
      */
     public static String clearJs(String locator) {
         String js = "var e = " + selector(locator) + ";" +
+                " if (!e) return;" +
                 " e.focus();" +
-                " e.value = '';" +
+                " var proto = e.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;" +
+                " var setter = Object.getOwnPropertyDescriptor(proto, 'value');" +
+                " if (setter && setter.set) { setter.set.call(e, ''); }" +
+                " else { e.value = ''; }" +
                 " e.dispatchEvent(new Event('input', { bubbles: true }));" +
                 " e.dispatchEvent(new Event('change', { bubbles: true }))";
         return wrapInFunctionInvoke(js);

--- a/karate-core/src/main/java/io/karatelabs/driver/w3c/W3cDriver.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/w3c/W3cDriver.java
@@ -379,9 +379,15 @@ public class W3cDriver implements Driver {
         } else {
             // v1 pattern: input is the ONE operation that uses native W3C sendKeys
             // because JS value assignment doesn't trigger framework input event handlers
-            String elementId = findElementIdWithRetry(locator);
             eval(Locators.clearJs(locator));
-            session.sendKeys(elementId, value);
+            String elementId = findElementIdWithRetry(locator);
+
+            try {
+                session.sendKeys(elementId, value);
+            } catch (Exception e) {
+                logger.warn("Native sendKeys failed. Falling back to JS injection.");
+                eval(Locators.inputJs(locator, value));
+            }
         }
         return BaseElement.existing(this, locator);
     }

--- a/karate-core/src/main/java/io/karatelabs/driver/w3c/W3cSession.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/w3c/W3cSession.java
@@ -93,7 +93,7 @@ public class W3cSession {
         URI uri = URI.create(baseUrl + "/session");
         HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(uri)
-                .header("Content-Type", "application/json")
+                .header("Content-Type", "application/json; charset=utf-8")
                 .timeout(timeout);
 
         String userInfo = uri.getUserInfo();
@@ -408,7 +408,7 @@ public class W3cSession {
         logger.trace("POST {} : {}", path, json);
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
-                .header("Content-Type", "application/json")
+                .header("Content-Type", "application/json; charset=utf-8")
                 .timeout(timeout)
                 .POST(HttpRequest.BodyPublishers.ofString(json))
                 .build();


### PR DESCRIPTION
## Description

There are two issues addressed in this PR. I've bundled them together because I don't currently have a solution for testing these fixes and thought it would be good to discuss them together.

1. When using the w3c driver with a selenium host, we must use a `Content-Type` header of `application/json; charset=utf-8` (see the [selenium src](https://github.com/SeleniumHQ/selenium/blob/9045e3bbaec4ac220d64e9e9def06546f1d81f37/java/src/org/openqa/selenium/grid/web/CheckContentTypeHeader.java) for reference)
2. When using the w3c driver to drive a Safari browser on iOS via appium, `input` does not work / throws an exception like below. The only solution was to catch the exception and fallback to JS, but that needed some compatibility tweaks to work properly with a reactive frontend framework like React / Vue.js:
     ```json
     {
       "message": "An element command failed because the referenced element is no longer attached to the DOM.",
     }
     ```

The changes in the PR solved both issues (i.e. features now run correctly against selenium hosts and `input` functions on iOS Safari against an appium host). The unfortunate part is that I don't have any mechanism to create a reproducer / unit tests for these changes. I'm happy to implement tests if there is a mechanism in place and I just missed it.

## Related Issues

https://github.com/karatelabs/karate/issues/2851

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [x] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [ ] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
