### PR TITLE
fix(js): per-Engine state isolation for built-in constructors and prototypes

### DIFF
--- a/docs/JS_ENGINE.md
+++ b/docs/JS_ENGINE.md
@@ -145,9 +145,9 @@ Two distinct families:
   `attrs` / `attrsExplicit` / `tombstoned` fields so `JsGlobalThis` can
   surface every observable globalThis state from a single store.
 
-The `INTRINSIC` bit on `attrs` lets per-Engine reset (`clearEngineState()`)
-distinguish install-time intrinsics (preserve across engine reuse) from
-user-set entries (clear on reset). The `WRITABLE` bit is meaningless for
+The `INTRINSIC` bit on `attrs` marks install-time intrinsics (vs user-set
+entries) — informational for strict-mode checks and introspection; nothing
+resets on it. The `WRITABLE` bit is meaningless for
 accessors and not consulted by `AccessorSlot`; the spec's "omit `writable`
 from descriptor output for accessors" is handled in
 `JsObjectConstructor.buildDescriptor` by branching on the slot family.
@@ -157,7 +157,8 @@ from descriptor output for accessors" is handled in
 The engine uses singleton prototype objects for method inheritance, matching JavaScript's prototype chain:
 
 ```
-Singleton Prototypes (shared JVM-wide; userProps reset per Engine):
+Singleton Prototypes (shared JVM-wide and immutable; user props are
+per-Engine overlays resolved via Engine.current()):
     JsObjectPrototype.INSTANCE   ← null (root of chain)
     JsArrayPrototype.INSTANCE    ← JsObjectPrototype.INSTANCE
     JsStringPrototype.INSTANCE   ← JsObjectPrototype.INSTANCE
@@ -174,34 +175,41 @@ Singleton Prototypes (shared JVM-wide; userProps reset per Engine):
                                  ← JsErrorPrototype.ERROR
 
 Constructor Functions (for static methods like Array.isArray, Date.UTC):
-    JsObjectConstructor.INSTANCE   → prototype: JsObjectPrototype.INSTANCE
-    JsArrayConstructor.INSTANCE    → prototype: JsArrayPrototype.INSTANCE
-    JsStringConstructor.INSTANCE   → prototype: JsStringPrototype.INSTANCE
-    JsNumberConstructor.INSTANCE   → prototype: JsNumberPrototype.INSTANCE
-    JsBigIntConstructor.INSTANCE   → prototype: JsBigIntPrototype.INSTANCE
-    JsDateConstructor.INSTANCE     → prototype: JsDatePrototype.INSTANCE
-    JsFunctionConstructor.INSTANCE → prototype: JsFunctionPrototype.INSTANCE
-    JsMapConstructor.INSTANCE      → prototype: JsMapPrototype.INSTANCE
-    JsSetConstructor.INSTANCE      → prototype: JsSetPrototype.INSTANCE
-    JsErrorConstructor.{ERROR,TYPE_ERROR,RANGE_ERROR,SYNTAX_ERROR,
-        REFERENCE_ERROR,URI_ERROR,EVAL_ERROR,AGGREGATE_ERROR}
-                                   → prototype: matching JsErrorPrototype.*
-    (JsBoolean has a prototype but no constructor wrapper class — the
-     Boolean global is registered directly as a callable in ContextRoot.)
+    PER-ENGINE instances (not JVM singletons), created lazily by
+    ContextRoot.builtinConstructor(name) and cached in the engine's
+    bindings — like JsMath always was:
+    JsObjectConstructor   → prototype: JsObjectPrototype.INSTANCE
+    JsArrayConstructor    → prototype: JsArrayPrototype.INSTANCE
+    JsStringConstructor   → prototype: JsStringPrototype.INSTANCE
+    JsNumberConstructor   → prototype: JsNumberPrototype.INSTANCE
+    JsBooleanConstructor  → prototype: JsBooleanPrototype.INSTANCE
+    JsBigIntConstructor   → prototype: JsBigIntPrototype.INSTANCE
+    JsDateConstructor     → prototype: JsDatePrototype.INSTANCE
+    JsFunctionConstructor → prototype: JsFunctionPrototype.INSTANCE
+    JsMapConstructor      → prototype: JsMapPrototype.INSTANCE
+    JsSetConstructor      → prototype: JsSetPrototype.INSTANCE
+    JsRegexConstructor    → prototype: JsRegexPrototype.INSTANCE
+    JsErrorConstructor ×8 (Error, TypeError, RangeError, SyntaxError,
+        ReferenceError, URIError, EvalError, AggregateError)
+                          → prototype: matching JsErrorPrototype.*
 ```
 
 **Built-in prototypes accept user-added properties** per spec — `Array.prototype`
 methods are configurable + writable, so `Array.prototype.foo = ...` works and
-overrides on lookup. The `Prototype` base class carries a `userProps` map for
-this; the built-in methods themselves are immutable (cannot be removed via
+overrides on lookup. User props live in a per-Engine overlay
+(`Engine.protoUserProps`, resolved through `Prototype.userProps()`); the
+built-in methods themselves are immutable (cannot be removed via
 `removeMember` unless tombstoned-on-delete per the
 [Spec Invariants § Property attributes](#property-attributes) rules).
 
-**Per-Engine isolation.** The prototypes are JVM-wide singletons but their
-`userProps` reset on every `new Engine()` via `Prototype.clearAllUserProps()`
-+ `JsObject.clearAllEngineState()` — otherwise a previous test that did
-`Map.prototype.set = function() { throw ... }` would poison the next session.
-See [Spec Invariants § Prototype machinery](#prototype-machinery) for the
+**Per-Engine isolation.** The prototypes are JVM-wide singletons, but all
+their mutable state is per-Engine: user props resolve through the thread's
+current engine (`Engine.current()`, an eval-scoped ThreadLocal) and die with
+it, so `Map.prototype.set = function() { throw ... }` in one Engine can
+neither poison another Engine nor be wiped by one — concurrent engines are
+fully isolated with no reset step. The constructors are per-Engine instances
+outright, so their mutable state needs no special handling. See
+[Spec Invariants § Prototype machinery](#prototype-machinery) for the
 full mechanism.
 
 User-created objects, arrays, and functions remain fully mutable:
@@ -222,25 +230,34 @@ function f() {}; f.meta = "data";        // OK
 // Base class for built-in prototype objects
 abstract class Prototype implements ObjectLike {
     private final Prototype __proto__;
-    // Each entry is a PropertySlot — DataSlot for user-added values,
+    // Install-time built-in members; immutable post-construction (lazy
+    // entries cache inside their LazyRef holder, never written back), so
+    // the map is safe under concurrent engines. User mutations land in the
+    // per-Engine overlay and shadow these.
+    private final Map<String, Object> builtins = new LinkedHashMap<>();
+
+    // The current Engine's user-prop overlay for this prototype (null when
+    // none). Each entry is a PropertySlot — DataSlot for user-added values,
     // AccessorSlot for accessor descriptors installed via
     // Object.defineProperty(Foo.prototype, "x", {get: ...}). The slot's
     // tombstoned flag shadows a built-in deleted via
-    // delete Foo.prototype.bar (was a separate Set<String> pre-refactor B).
-    private Map<String, PropertySlot> userProps;
-    // Install-time built-in members; immutable post-construction. User
-    // mutations land in userProps and shadow these.
-    private final Map<String, Object> builtins = new LinkedHashMap<>();
+    // delete Foo.prototype.bar. Resolved via Engine.current() (eval-scoped
+    // ThreadLocal); a JVM-wide monotonic anyUserProps flag short-circuits
+    // the lookup until any engine actually polyfills a prototype.
+    private Map<String, PropertySlot> userProps() { ... }
+    private Map<String, PropertySlot> userPropsForWrite() { ... }
 
     public final Object getMember(String name) {
-        // 1. User slot wins (data, accessor, or tombstone)
+        // 1. Per-Engine user slot wins (data, accessor, or tombstone)
+        Map<String, PropertySlot> userProps = userProps();
         PropertySlot s = userProps == null ? null : userProps.get(name);
         if (s != null) {
             if (s.tombstoned) return walkProto(name);
             return s instanceof DataSlot ds ? ds.value : null; // accessor → null at this seam
         }
-        // 2. Built-in lookup (resolves + caches LazyRef on first access)
-        Object builtin = resolveBuiltin(name);
+        // 2. Built-in lookup (LazyRef self-caches; ConstructorRef resolves
+        //    per access against the reading Engine's constructor instance)
+        Object builtin = resolveBuiltin(name, null);
         if (builtin != null) return builtin;
         // 3. Delegate to __proto__ chain
         return walkProto(name);
@@ -250,7 +267,7 @@ abstract class Prototype implements ObjectLike {
     public Object getMember(String name, Object receiver, CoreContext ctx) { ... }
 
     public void putMember(String name, Object value) {
-        if (userProps == null) userProps = new LinkedHashMap<>();
+        Map<String, PropertySlot> userProps = userPropsForWrite();
         PropertySlot existing = userProps.get(name);
         if (existing instanceof DataSlot ds) {
             ds.value = value;
@@ -291,7 +308,7 @@ class JsArrayPrototype extends Prototype {
 **Benefits:**
 - Single instance per type (memory efficient)
 - Spec-conformant: `Array.prototype.foo = ...` polyfill patterns work
-- Per-Engine reset prevents cross-session pollution
+- Per-Engine state isolation prevents cross-session (and cross-thread) pollution
 - Clean separation of constructor vs prototype
 - Methods inherited via standard prototype chain
 - `ObjectLike.getPrototype()` enables uniform chain walking
@@ -1459,27 +1476,41 @@ properties-of-the-X-prototype-object.js tests across Map / Set / Array /
 RegExp / Error / Date / Function / Number / Boolean / String / BigInt.
 
 **Per-Engine prototype isolation.** Built-in prototypes are JVM-wide
-singletons (e.g. `JsArrayPrototype.INSTANCE`), but their `userProps` must
-reset each time a new `Engine` is constructed — otherwise a previous test
-that did `Map.prototype.set = function() { throw ... }` poisons the next
-session. `Prototype` constructor registers each singleton in a static `ALL`
-list; `Engine()` calls `Prototype.clearAllUserProps()` which walks the list
-and clears each `userProps` map. Spec-compliant for sequential single-Engine
-usage (the realistic case); concurrent Engines in the same JVM still share
-the underlying singleton during overlapping windows. Performance impact:
-invisible — the loop is ~10 entries with usually-empty maps, lost in noise at
-script-eval scale.
+singletons (e.g. `JsArrayPrototype.INSTANCE`), but user mutations
+(`Map.prototype.set = function() { throw ... }`) are per-Engine state: they
+live in an overlay on the `Engine` (`Engine.protoUserProps`, keyed by
+prototype identity) and are resolved through the thread's *current engine*
+(`Engine.current()`, an eval-scoped ThreadLocal established with
+save/restore nesting by `Engine.evalInternal` / `evalRaw` and by
+`JsFunctionNode.call` for host-initiated invocations). One engine's
+prototype pollution is therefore invisible to — and indestructible by —
+every other engine, with no reset step at all; the overlay dies with its
+Engine. This replaced the historical clear-on-construct model
+(`Prototype.clearAllUserProps()` walking a static registry from
+`Engine.<init>`), which was correct only for sequential single-Engine usage:
+under concurrent engines, one thread's `new Engine()` wiped singleton state
+out from under another thread mid-evaluation (manifesting as intermittent
+`TypeError: Object.keys is not a function` in parallel suite runs — pinned
+by `EngineConcurrencyTest`). Hot-path cost: zero until any engine polyfills
+a prototype (a JVM-wide monotonic `anyUserProps` flag short-circuits the
+overlay lookup), one ThreadLocal read per prototype-level lookup after.
+The `builtins` install map on each prototype singleton is immutable
+post-construction (lazy entries cache inside their `LazyRef` holder rather
+than writing back), so concurrent readers never observe structural mutation.
 
-The same pattern holds on the constructor side via `JsObject.ENGINE_RESET_LIST`
-+ `clearEngineState()`. All nine built-in constructor singletons (Array /
-BigInt / Date / Function / Map / Number / Object / Set / String) register
-themselves; `Engine.<init>` invokes `JsObject.clearAllEngineState()` right
-after `Prototype.clearAllUserProps()`. Default `clearEngineState()` wipes
-`props` / extensibility flags; subclasses with intrinsic install routines
-override, call `super.clearEngineState()` first, then re-run
-`installIntrinsics()` (the install code is the single source of truth for
-what gets restored). The `INTRINSIC` bit on the slot's attrs byte is
-informational — it doesn't gate reset behavior.
+On the constructor side the problem dissolved rather than moved: the
+built-in constructors (Array / BigInt / Boolean / Date / Function / Map /
+Number / Object / RegExp / Set / String and the eight Error types) are
+**per-Engine instances**, not JVM singletons — created lazily by
+`ContextRoot.builtinConstructor(name)` and cached in the engine's bindings
+like `JsMath` always was. User mutations, tombstones, and freezes on
+`Object` / `Array` / etc. ride the ordinary `JsObject` machinery and are
+naturally engine-isolated; `JsObject.ENGINE_RESET_LIST` /
+`clearEngineState()` are gone. The `constructor` back-references on the
+shared prototype singletons (`Array.prototype.constructor === Array`)
+resolve per access through a `ConstructorRef` marker against the reading
+engine's instance — never cached in the shared `builtins` map. The
+`INTRINSIC` bit on the slot's attrs byte is informational.
 
 **Function declarations hoist** at the start of the enclosing program / block
 scope. `Interpreter.hoistFunctionDeclarations` walks immediate `STATEMENT >
@@ -1682,9 +1713,9 @@ backed `JsUint8Array` routes through the slow path so its
 was ever installed on a prototype's userProps in this Engine
 (`Prototype.isNumericPropPolluted == false`), HasProperty reduces to an
 in-bounds non-HOLE check on the dense list — no per-element
-`String.valueOf` or chain walk. The `numericPropPolluted` bit flips on
-the first `Array.prototype[i] = …` / `Object.prototype[i] = …` write in
-the session and resets per-Engine in `Prototype.clearAllUserProps`. Slow
+`String.valueOf` or chain walk. The `numericPropPolluted` bit lives on
+the Engine, flips on the first `Array.prototype[i] = …` /
+`Object.prototype[i] = …` write in the session, and dies with it. Slow
 path (proto pollution, custom proto, descriptors, generic ObjectLike
 receiver) walks `hasPropertyChain` and `getMember` per index.
 
@@ -1821,17 +1852,17 @@ through `Interpreter.bindThisForCall` (lenient sloppy substitution).
 
 ### Built-in accessor descriptors on prototypes
 
-**Spec accessor getters live in `Prototype.builtins` so they survive
-per-Engine reset.** ECMA-262 declares
+**Spec accessor getters live in `Prototype.builtins` — the shared,
+immutable, install-time tier.** ECMA-262 declares
 `RegExp.prototype.{source, flags, global, ignoreCase, multiline, dotAll,
 sticky, unicode}` as accessor descriptors on the prototype, NOT as own
 properties of instances — `Object.getOwnPropertyDescriptor(RegExp.prototype,
 'source').get` must be a function with `.length === 0` and the proto-self
 sentinel branch (`get.call(RegExp.prototype) === "(?:)"`). User-installed
 accessors via `Object.defineProperty` go through `defineOwnAccessor`
-into `userProps` and shadow these (consistent with the data-slot
-shadowing rule); built-in accessors go through `installAccessor` into
-`builtins`, which is NOT cleared by `Prototype.clearAllUserProps`. The
+into the per-Engine user props and shadow these (consistent with the
+data-slot shadowing rule); built-in accessors go through `installAccessor`
+into `builtins`, the immutable shared tier. The
 read seam `Prototype.getMember(name, receiver, ctx)` walks userProps →
 builtins (with `AccessorSlot.read` dispatch) → proto chain;
 `getOwnSlot` and `getOwnAttrs` mirror the precedence so descriptor
@@ -2460,8 +2491,8 @@ public final class JsUndefined implements JsValue {
 - Cleaner type hierarchy with compiler-enforced exhaustive handling
 - Single `instanceof JsValue` check replaces scattered type checks
 - `getJsValue()` provides uniform unwrapping for internal operations
-- Singleton prototypes shared across Engine instances (`userProps` reset per
-  Engine — see [Spec Invariants § Prototype machinery](#prototype-machinery))
+- Singleton prototypes shared across Engine instances (user props are
+  per-Engine overlays — see [Spec Invariants § Prototype machinery](#prototype-machinery))
 
 ---
 

--- a/karate-js/src/main/java/io/karatelabs/js/ContextRoot.java
+++ b/karate-js/src/main/java/io/karatelabs/js/ContextRoot.java
@@ -28,6 +28,8 @@ import io.karatelabs.parser.Node;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -226,6 +228,50 @@ class ContextRoot implements Context {
 
     //=== Built-in globals ==============================================================================================
 
+    // This Engine's built-in constructor instances (Object, Array, …,
+    // AggregateError). Per-Engine — NOT JVM singletons — so user mutations,
+    // tombstones, and freezes on one engine's constructors can be neither
+    // observed nor destroyed by another engine running concurrently. Lazily
+    // created per name; identity is stable within the Engine so
+    // `Array.prototype.constructor === Array` holds. The prototype objects
+    // they expose (`Array.prototype` etc.) remain JVM-wide singletons.
+    private Map<String, JsFunction> builtinConstructors;
+
+    JsFunction builtinConstructor(String name) {
+        if (builtinConstructors == null) {
+            builtinConstructors = new HashMap<>();
+        }
+        JsFunction c = builtinConstructors.get(name);
+        if (c == null) {
+            c = switch (name) {
+                case "Array" -> new JsArrayConstructor();
+                case "BigInt" -> new JsBigIntConstructor();
+                case "Boolean" -> new JsBooleanConstructor();
+                case "Date" -> new JsDateConstructor();
+                case "Function" -> new JsFunctionConstructor();
+                case "Map" -> new JsMapConstructor();
+                case "Number" -> new JsNumberConstructor();
+                case "Object" -> new JsObjectConstructor();
+                case "RegExp" -> new JsRegexConstructor();
+                case "Set" -> new JsSetConstructor();
+                case "String" -> new JsStringConstructor();
+                case "Error" -> new JsErrorConstructor(JsErrorPrototype.ERROR, 1);
+                case "TypeError" -> new JsErrorConstructor(JsErrorPrototype.TYPE_ERROR, 1);
+                case "RangeError" -> new JsErrorConstructor(JsErrorPrototype.RANGE_ERROR, 1);
+                case "SyntaxError" -> new JsErrorConstructor(JsErrorPrototype.SYNTAX_ERROR, 1);
+                case "ReferenceError" -> new JsErrorConstructor(JsErrorPrototype.REFERENCE_ERROR, 1);
+                case "URIError" -> new JsErrorConstructor(JsErrorPrototype.URI_ERROR, 1);
+                case "EvalError" -> new JsErrorConstructor(JsErrorPrototype.EVAL_ERROR, 1);
+                case "AggregateError" -> new JsErrorConstructor(JsErrorPrototype.AGGREGATE_ERROR, 2);
+                default -> null;
+            };
+            if (c != null) {
+                builtinConstructors.put(name, c);
+            }
+        }
+        return c;
+    }
+
     private Object initGlobal(String key) {
         return switch (key) {
             case "console" -> new JsConsole(this);
@@ -277,30 +323,14 @@ class ContextRoot implements Context {
                 // indirect-eval semantics: evaluate in the global (root) scope
                 return engine.evalRaw(s);
             };
-            case "Array" -> JsArrayConstructor.INSTANCE;
-            case "Date" -> JsDateConstructor.INSTANCE;
-            case "Function" -> JsFunctionConstructor.INSTANCE;
-            case "Error" -> JsErrorConstructor.ERROR;
+            case "Array", "Date", "Function", "Error", "Map", "Number", "BigInt", "Boolean",
+                 "Object", "RegExp", "Set", "String", "TypeError", "ReferenceError", "RangeError",
+                 "SyntaxError", "URIError", "EvalError", "AggregateError" -> builtinConstructor(key);
             case "Infinity" -> Double.POSITIVE_INFINITY;
             case "Java" -> new JsJava(bridge);
             case "JSON" -> new JsJson();
-            case "Map" -> JsMapConstructor.INSTANCE;
             case "Math" -> new JsMath();
             case "NaN" -> Double.NaN;
-            case "Number" -> JsNumberConstructor.INSTANCE;
-            case "BigInt" -> JsBigIntConstructor.INSTANCE;
-            case "Boolean" -> JsBooleanConstructor.INSTANCE;
-            case "Object" -> JsObjectConstructor.INSTANCE;
-            case "RegExp" -> JsRegexConstructor.INSTANCE;
-            case "Set" -> JsSetConstructor.INSTANCE;
-            case "String" -> JsStringConstructor.INSTANCE;
-            case "TypeError" -> JsErrorConstructor.TYPE_ERROR;
-            case "ReferenceError" -> JsErrorConstructor.REFERENCE_ERROR;
-            case "RangeError" -> JsErrorConstructor.RANGE_ERROR;
-            case "SyntaxError" -> JsErrorConstructor.SYNTAX_ERROR;
-            case "URIError" -> JsErrorConstructor.URI_ERROR;
-            case "EvalError" -> JsErrorConstructor.EVAL_ERROR;
-            case "AggregateError" -> JsErrorConstructor.AGGREGATE_ERROR;
             case "TextDecoder" -> new JsTextDecoder();
             case "TextEncoder" -> new JsTextEncoder();
             case "Uint8Array" -> new JsUint8Array(0);

--- a/karate-js/src/main/java/io/karatelabs/js/Engine.java
+++ b/karate-js/src/main/java/io/karatelabs/js/Engine.java
@@ -30,12 +30,49 @@ import io.karatelabs.parser.NodeType;
 import io.karatelabs.parser.ParserException;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
 public class Engine {
 
     public static boolean DEBUG = false;
+
+    /**
+     * The Engine currently executing JS on this thread. Established with
+     * save/restore nesting by {@link #evalInternal} / {@link #evalRaw}, and by
+     * {@code JsFunctionNode.call} when a host invokes a function directly
+     * (possibly with a null caller context) — the function body then runs
+     * under its declaring Engine. Lets the JVM-wide built-in prototype
+     * singletons resolve their per-Engine mutable state (user-added
+     * properties, {@code constructor} cross-references) without threading a
+     * context through every property seam — including the ctx-less raw seams
+     * like the 1-arg {@code getMember}.
+     */
+    private static final ThreadLocal<Engine> CURRENT = new ThreadLocal<>();
+
+    /** The Engine currently executing JS on this thread, or null outside JS execution. */
+    static Engine current() {
+        return CURRENT.get();
+    }
+
+    /** Make {@code engine} current for this thread; returns the previous
+     *  value, which the caller MUST restore via {@link #exit} (try/finally). */
+    static Engine enter(Engine engine) {
+        Engine prev = CURRENT.get();
+        CURRENT.set(engine);
+        return prev;
+    }
+
+    static void exit(Engine prev) {
+        if (prev == null) {
+            // remove (not set-null) so pooled threads don't pin a stale entry
+            CURRENT.remove();
+        } else {
+            CURRENT.set(prev);
+        }
+    }
 
     // Single global store. Holds user-visible bindings (Engine.put / top-level
     // var / implicit globals) AND hidden entries (putRootBinding-injected
@@ -52,17 +89,41 @@ public class Engine {
 
     private final ContextRoot root = new ContextRoot(this);
 
-    public Engine() {
-        // Built-in prototype singletons (JsArrayPrototype, JsMapPrototype, …) accumulate
-        // user-added properties across the JVM's lifetime. Reset them per Engine so test
-        // harnesses that overwrite e.g. Map.prototype.set don't poison the next session.
-        Prototype.clearAllUserProps();
-        // Same problem on the JsObject side: built-in constructor singletons
-        // (JsNumberConstructor.INSTANCE, JsObjectConstructor.INSTANCE, …) accumulate
-        // user-set properties / attribute overrides / tombstones from `delete Number.x`
-        // across the JVM. Reset their per-Engine mutable state so propertyHelper-style
-        // destructive probes don't leak to subsequent tests.
-        JsObject.clearAllEngineState();
+    // Per-Engine user-added properties on the JVM-wide built-in prototype
+    // singletons (e.g. Array.prototype.foo = ...). Keyed by prototype
+    // identity, lazily allocated — almost no script mutates built-in
+    // prototypes. Dies with this Engine, so prototype pollution can neither
+    // leak into another Engine nor be destroyed by one (the historical
+    // clear-on-construct reset wiped this state JVM-wide, which corrupted
+    // engines mid-evaluation on other threads).
+    private Map<Prototype, Map<String, PropertySlot>> protoUserProps;
+
+    // True iff user code installed a canonical numeric key on a built-in
+    // prototype in this Engine session. See Prototype.isNumericPropPolluted.
+    boolean numericPropPolluted;
+
+    /** Per-Engine user-property overlay for {@code proto} — null when absent
+     *  and {@code create} is false. Engine instances are single-threaded at a
+     *  time (same posture as {@link BindingsStore}), so plain maps suffice. */
+    Map<String, PropertySlot> protoUserProps(Prototype proto, boolean create) {
+        if (protoUserProps == null) {
+            if (!create) {
+                return null;
+            }
+            protoUserProps = new HashMap<>();
+        }
+        Map<String, PropertySlot> map = protoUserProps.get(proto);
+        if (map == null && create) {
+            map = new LinkedHashMap<>();
+            protoUserProps.put(proto, map);
+        }
+        return map;
+    }
+
+    /** This Engine's instance of a built-in constructor global ("Array",
+     *  "TypeError", …) — created lazily, stable identity per Engine. */
+    JsFunction builtinConstructor(String name) {
+        return root.builtinConstructor(name);
     }
 
     public Object eval(Node program) {
@@ -194,7 +255,12 @@ public class Engine {
         JsParser parser = new JsParser(Resource.text(text));
         Node program = parser.parse();
         CoreContext context = new CoreContext(root, null, 0, program, ContextScope.GLOBAL, bindings);
-        return Interpreter.eval(program, context);
+        Engine prev = enter(this);
+        try {
+            return Interpreter.eval(program, context);
+        } finally {
+            exit(prev);
+        }
     }
 
     private Object evalInternal(Resource resource, Map<String, Object> localVars) {
@@ -203,6 +269,7 @@ public class Engine {
     }
 
     private Object evalInternal(Node program, Map<String, Object> localVars) {
+        Engine prevEngine = enter(this);
         try {
             root.evalId++;
             CoreContext context;
@@ -246,6 +313,8 @@ public class Engine {
             String jsErrorName = e instanceof EngineException ee ? ee.getJsErrorName() : null;
             String jsMessage = e instanceof EngineException ee ? ee.getJsMessage() : null;
             throw new EngineException(message, e, jsErrorName, jsMessage);
+        } finally {
+            exit(prevEngine);
         }
     }
 

--- a/karate-js/src/main/java/io/karatelabs/js/JsArrayConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsArrayConstructor.java
@@ -31,23 +31,19 @@ import java.util.Map;
 /**
  * JavaScript Array constructor function.
  * <p>
- * Singleton; static methods + the {@code prototype} slot are eagerly
- * installed at construction time as own properties with spec attrs:
+ * One instance per Engine; static methods + the {@code prototype} slot are
+ * eagerly installed at construction time as own properties with spec attrs:
  * methods are {@code W | C} (non-enumerable), {@code prototype} is
- * all-false. {@link #clearEngineState} re-runs the install on per-Engine
- * reset so user mutations from a prior session don't leak.
+ * all-false. Per-Engine instances keep user mutations isolated to their
+ * session — no cross-Engine reset needed.
  */
 class JsArrayConstructor extends JsFunction {
-
-    static final JsArrayConstructor INSTANCE = new JsArrayConstructor();
-
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
 
-    private JsArrayConstructor() {
+    JsArrayConstructor() {
         this.name = "Array";
         this.length = 1;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
@@ -55,12 +51,6 @@ class JsArrayConstructor extends JsFunction {
         defineOwn("isArray", new JsBuiltinMethod("isArray", 1, (JsInvokable) this::isArray), METHOD_ATTRS);
         defineOwn("of", new JsBuiltinMethod("of", 0, (JsInvokable) this::of), METHOD_ATTRS);
         defineOwn("prototype", JsArrayPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsArrayPrototype.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsArrayPrototype.java
@@ -103,10 +103,9 @@ class JsArrayPrototype extends Prototype {
         install("toSorted", 1, this::toSorted);
         install("toSpliced", 2, this::toSpliced);
         install("group", 1, this::group);
-        // Spec §23.1.3.1: Array.prototype.constructor === Array. installLazy
-        // because JsArrayConstructor.INSTANCE may not be ready at static-init
-        // time of this prototype singleton (forward reference).
-        installLazy("constructor", () -> JsArrayConstructor.INSTANCE);
+        // Spec §23.1.3.1: Array.prototype.constructor === Array — resolved
+        // per access against the reading Engine's constructor instance.
+        installConstructor("Array");
         install(IterUtils.SYMBOL_ITERATOR, 0, IterUtils.SYMBOL_ITERATOR_METHOD);
     }
 

--- a/karate-js/src/main/java/io/karatelabs/js/JsBigIntConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsBigIntConstructor.java
@@ -32,28 +32,18 @@ import java.math.BigInteger;
  * Provides {@code BigInt(value)} conversion plus {@code asIntN}/{@code asUintN}.
  */
 class JsBigIntConstructor extends JsFunction {
-
-    static final JsBigIntConstructor INSTANCE = new JsBigIntConstructor();
-
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
 
-    private JsBigIntConstructor() {
+    JsBigIntConstructor() {
         this.name = "BigInt";
         this.length = 1;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
         defineOwn("asIntN", new JsBuiltinMethod("asIntN", 2, this::asIntN), METHOD_ATTRS);
         defineOwn("asUintN", new JsBuiltinMethod("asUintN", 2, this::asUintN), METHOD_ATTRS);
         defineOwn("prototype", JsBigIntPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsBooleanConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsBooleanConstructor.java
@@ -33,24 +33,14 @@ package io.karatelabs.js;
  * by {@code new Boolean(x)}.
  */
 class JsBooleanConstructor extends JsFunction {
-
-    static final JsBooleanConstructor INSTANCE = new JsBooleanConstructor();
-
-    private JsBooleanConstructor() {
+    JsBooleanConstructor() {
         this.name = "Boolean";
         this.length = 1;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
         defineOwn("prototype", JsBooleanPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsDateConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsDateConstructor.java
@@ -30,16 +30,12 @@ import java.util.Date;
  * Provides static methods like Date.now, Date.parse, Date.UTC.
  */
 class JsDateConstructor extends JsFunction {
-
-    static final JsDateConstructor INSTANCE = new JsDateConstructor();
-
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
 
-    private JsDateConstructor() {
+    JsDateConstructor() {
         this.name = "Date";
         this.length = 7;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
@@ -48,12 +44,6 @@ class JsDateConstructor extends JsFunction {
         defineOwn("UTC", new JsBuiltinMethod("UTC", 7, (JsCallable) (ctx, args) ->
                 utcWithContext(ctx instanceof CoreContext c ? c : null, args)), METHOD_ATTRS);
         defineOwn("prototype", JsDatePrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsDatePrototype.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsDatePrototype.java
@@ -68,7 +68,7 @@ class JsDatePrototype extends Prototype {
         super(JsObjectPrototype.INSTANCE);
         // Spec lengths from §21.4.4: most getters and toFoo helpers take 0,
         // setters take their own arity (setMilliseconds=1, setMinutes=3, etc.).
-        installLazy("constructor", () -> JsDateConstructor.INSTANCE);
+        installConstructor("Date");
         install("getTime", 0, this::getTime);
         install("valueOf", 0, this::getTime);
         install("toString", 0, this::toStringMethod);

--- a/karate-js/src/main/java/io/karatelabs/js/JsErrorConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsErrorConstructor.java
@@ -29,43 +29,24 @@ import java.util.List;
 /**
  * Per-spec constructor for Error and its native subclasses (§20.5).
  * <p>
- * One singleton per error type. Each carries its own {@link JsErrorPrototype}
- * as the {@code prototype} own intrinsic; instances created via
- * {@code Error("msg")} or {@code new Error("msg")} carry that prototype as
- * their {@code __proto__}. Per spec the call form and the construct form are
- * identical (§20.5.1.1 step 1).
+ * One instance per error type per Engine (created via
+ * {@code ContextRoot.builtinConstructor}). Each carries its error type's
+ * {@link JsErrorPrototype} singleton as the {@code prototype} own intrinsic;
+ * instances created via {@code Error("msg")} or {@code new Error("msg")}
+ * carry that prototype as their {@code __proto__}. Per spec the call form
+ * and the construct form are identical (§20.5.1.1 step 1).
  */
 class JsErrorConstructor extends JsFunction {
-
-    static final JsErrorConstructor ERROR = new JsErrorConstructor(JsErrorPrototype.ERROR, 1);
-    static final JsErrorConstructor TYPE_ERROR = new JsErrorConstructor(JsErrorPrototype.TYPE_ERROR, 1);
-    static final JsErrorConstructor RANGE_ERROR = new JsErrorConstructor(JsErrorPrototype.RANGE_ERROR, 1);
-    static final JsErrorConstructor SYNTAX_ERROR = new JsErrorConstructor(JsErrorPrototype.SYNTAX_ERROR, 1);
-    static final JsErrorConstructor REFERENCE_ERROR = new JsErrorConstructor(JsErrorPrototype.REFERENCE_ERROR, 1);
-    static final JsErrorConstructor URI_ERROR = new JsErrorConstructor(JsErrorPrototype.URI_ERROR, 1);
-    static final JsErrorConstructor EVAL_ERROR = new JsErrorConstructor(JsErrorPrototype.EVAL_ERROR, 1);
-    static final JsErrorConstructor AGGREGATE_ERROR = new JsErrorConstructor(JsErrorPrototype.AGGREGATE_ERROR, 2);
 
     private static final byte MESSAGE_ATTRS = WRITABLE | CONFIGURABLE;
 
     private final JsErrorPrototype errorPrototype;
 
-    private JsErrorConstructor(JsErrorPrototype prototype, int length) {
+    JsErrorConstructor(JsErrorPrototype prototype, int length) {
         this.name = prototype.getTypeName();
         this.length = length;
         this.errorPrototype = prototype;
-        installIntrinsics();
-        registerForEngineReset();
-    }
-
-    private void installIntrinsics() {
         defineOwn("prototype", errorPrototype, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override
@@ -157,19 +138,6 @@ class JsErrorConstructor extends JsFunction {
             if (o.isOwnProperty(name)) return true;
         }
         return false;
-    }
-
-    static JsErrorConstructor forName(String name) {
-        return switch (name) {
-            case "TypeError" -> TYPE_ERROR;
-            case "RangeError" -> RANGE_ERROR;
-            case "SyntaxError" -> SYNTAX_ERROR;
-            case "ReferenceError" -> REFERENCE_ERROR;
-            case "URIError" -> URI_ERROR;
-            case "EvalError" -> EVAL_ERROR;
-            case "AggregateError" -> AGGREGATE_ERROR;
-            default -> ERROR;
-        };
     }
 
 }

--- a/karate-js/src/main/java/io/karatelabs/js/JsErrorPrototype.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsErrorPrototype.java
@@ -49,9 +49,9 @@ class JsErrorPrototype extends Prototype {
         super(parent);
         this.typeName = name;
         install("name", name);
-        // Lazy ref — JsErrorConstructor singletons aren't initialized at this point in the
-        // static-init cycle. Resolved on first JS-side read (Error.prototype.constructor).
-        installLazy("constructor", () -> JsErrorConstructor.forName(name));
+        // Resolved per access against the reading Engine's constructor instance
+        // for this error type ("Error", "TypeError", ...).
+        installConstructor(name);
         if (isRoot) {
             install("message", "");
             install("toString", 0, JsErrorPrototype::toStringMethod);

--- a/karate-js/src/main/java/io/karatelabs/js/JsFunctionConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsFunctionConstructor.java
@@ -36,24 +36,14 @@ package io.karatelabs.js;
  * resolves to for any user or built-in function, satisfying spec identity.
  */
 class JsFunctionConstructor extends JsFunction {
-
-    static final JsFunctionConstructor INSTANCE = new JsFunctionConstructor();
-
-    private JsFunctionConstructor() {
+    JsFunctionConstructor() {
         this.name = "Function";
         this.length = 1;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
         defineOwn("prototype", JsFunctionPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsFunctionNode.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsFunctionNode.java
@@ -139,7 +139,21 @@ class JsFunctionNode extends JsFunction {
         functionContext.activeFunction = arrow
                 ? (declaredContext != null ? declaredContext.activeFunction : null)
                 : this;
-        return bindArgsAndExecute(functionContext, parentContext, args);
+        // Hosts may invoke a shared function directly (null / foreign caller
+        // context, outside any Engine.eval). The body executes against the
+        // declaring Engine's globals, so make that engine current for
+        // singleton-overlay resolution. Common case (JS-to-JS call under the
+        // same engine's eval) pays one ThreadLocal read and skips the switch.
+        Engine declaringEngine = declaredContext == null ? null : declaredContext.getEngine();
+        if (declaringEngine == null || declaringEngine == Engine.current()) {
+            return bindArgsAndExecute(functionContext, parentContext, args);
+        }
+        Engine prevEngine = Engine.enter(declaringEngine);
+        try {
+            return bindArgsAndExecute(functionContext, parentContext, args);
+        } finally {
+            Engine.exit(prevEngine);
+        }
     }
 
     // Called by Interpreter when context is pre-prepared with closure info

--- a/karate-js/src/main/java/io/karatelabs/js/JsFunctionPrototype.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsFunctionPrototype.java
@@ -42,7 +42,7 @@ class JsFunctionPrototype extends Prototype {
         install("apply", 2, this::applyMethod);
         install("bind", 1, this::bindMethod);
         install("toString", 0, this::toStringMethod);
-        installLazy("constructor", () -> JsFunctionConstructor.INSTANCE);
+        installConstructor("Function");
     }
 
     // Helper to get JsCallable from this context (accepts both JsFunction and JsCallable)

--- a/karate-js/src/main/java/io/karatelabs/js/JsMapConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsMapConstructor.java
@@ -32,14 +32,10 @@ import java.util.List;
  * user-overridden {@code Map.prototype.set} is honored during construction.
  */
 class JsMapConstructor extends JsFunction {
-
-    static final JsMapConstructor INSTANCE = new JsMapConstructor();
-
-    private JsMapConstructor() {
+    JsMapConstructor() {
         this.name = "Map";
         // length=0 — Map() takes optional iterable; spec arity is 0.
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
@@ -56,12 +52,6 @@ class JsMapConstructor extends JsFunction {
         // coercion mode) — verified by negativeZero.js.
         return GroupByImpl.toMap(
                 GroupByImpl.run(items, callback, /* propertyMode= */ false, context));
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsNumberConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsNumberConstructor.java
@@ -28,11 +28,10 @@ package io.karatelabs.js;
  * <p>
  * Static methods (isFinite / isInteger / isNaN / isSafeInteger) are wrapped in
  * {@link JsBuiltinMethod} so they expose spec {@code length} and {@code name}
- * as own properties. Method instances are cached per-Engine in {@code methodCache}
- * so {@code Number.isFinite === Number.isFinite} holds within a session and
- * tombstones from {@code delete Number.isFinite} are applied to a stable instance.
- * The cache is wiped per-Engine via {@link #clearEngineState()} (see the
- * {@code ENGINE_RESET_LIST} mechanism on {@link JsObject}).
+ * as own properties. One instance per Engine (created via
+ * {@code ContextRoot.builtinConstructor}), so {@code Number.isFinite ===
+ * Number.isFinite} holds within a session and user mutations / tombstones
+ * ({@code delete Number.isFinite}) stay isolated to their Engine.
  * <p>
  * {@link #hasOwnIntrinsic} and {@link #getOwnAttrs} declare each method, constant
  * and the {@code prototype} slot per spec so {@code getOwnPropertyDescriptor}
@@ -42,20 +41,16 @@ package io.karatelabs.js;
  * constructor's {@code prototype} is all-false.
  */
 class JsNumberConstructor extends JsFunction {
-
-    static final JsNumberConstructor INSTANCE = new JsNumberConstructor();
-
     private static final long MAX_SAFE_INTEGER = 9007199254740991L;
     private static final long MIN_SAFE_INTEGER = -9007199254740991L;
 
     private static final byte CONSTANT_ATTRS = PropertySlot.INTRINSIC;
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
 
-    private JsNumberConstructor() {
+    JsNumberConstructor() {
         this.name = "Number";
         this.length = 1;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
@@ -76,12 +71,6 @@ class JsNumberConstructor extends JsFunction {
         defineOwn("parseInt", ContextRoot.PARSE_INT, METHOD_ATTRS);
         defineOwn("parseFloat", ContextRoot.PARSE_FLOAT, METHOD_ATTRS);
         defineOwn("prototype", JsNumberPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsObject.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsObject.java
@@ -24,7 +24,6 @@
 package io.karatelabs.js;
 
 import java.util.*;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * JavaScript Object — own properties live in a single {@code props}
@@ -49,26 +48,6 @@ class JsObject implements ObjectLike, Map<String, Object> {
     static final byte ENUMERABLE = PropertySlot.ENUMERABLE;
     static final byte CONFIGURABLE = PropertySlot.CONFIGURABLE;
     static final byte ATTRS_DEFAULT = PropertySlot.ATTRS_DEFAULT;
-
-    /**
-     * JVM-wide singletons that must reset their per-Engine mutable state when a
-     * fresh {@link Engine} is constructed. Built-in constructor instances
-     * ({@code JsNumberConstructor.INSTANCE}, {@code JsObjectConstructor.INSTANCE},
-     * etc.) call {@link #registerForEngineReset()} to enroll themselves; the
-     * {@link Engine} constructor walks this list and invokes
-     * {@link #clearEngineState()} on each entry.
-     * <p>
-     * Per-Engine instances ({@code JsMath}, allocated fresh in
-     * {@code ContextRoot.initGlobal}) are GC'd with their owning Engine and must
-     * NOT register here.
-     */
-    private static final List<JsObject> ENGINE_RESET_LIST = new CopyOnWriteArrayList<>();
-
-    static void clearAllEngineState() {
-        for (JsObject o : ENGINE_RESET_LIST) {
-            o.clearEngineState();
-        }
-    }
 
     /**
      * Own-property storage. One {@link Slot} per name carries the value plus
@@ -548,38 +527,6 @@ class JsObject implements ObjectLike, Map<String, Object> {
                 }
             }
         }
-    }
-
-    /**
-     * Enroll this JsObject in {@link #ENGINE_RESET_LIST} — call from a singleton
-     * constructor whose lifetime exceeds a single {@link Engine} session (typically
-     * {@code <Constructor>.INSTANCE} fields referenced from
-     * {@code ContextRoot.initGlobal}). See {@link #ENGINE_RESET_LIST} for the
-     * criteria; per-Engine instances must not register.
-     */
-    protected final void registerForEngineReset() {
-        ENGINE_RESET_LIST.add(this);
-    }
-
-    /**
-     * Reset per-Engine mutable state on this singleton so user-set properties /
-     * tombstones / extensibility flips from one test don't bleed into the next.
-     * Default clears {@code props} and the three extensibility flags. Subclasses
-     * with additional caches (e.g. a {@code methodCache} of wrapped
-     * {@link JsBuiltinMethod} instances) should override and call
-     * {@code super.clearEngineState()} first.
-     */
-    protected void clearEngineState() {
-        if (props != null) props.clear();
-        nonExtensible = false;
-        sealed = false;
-        frozen = false;
-        // Subclasses with eager-installed intrinsics override and call
-        // {@code super.clearEngineState()} first, then re-run their
-        // {@code installIntrinsics()} routine — the install code is the
-        // single source of truth for what gets restored. The {@link
-        // PropertySlot#INTRINSIC} bit stays informational (strict-mode
-        // checks, introspection) rather than reset-controlling.
     }
 
     /**

--- a/karate-js/src/main/java/io/karatelabs/js/JsObjectConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsObjectConstructor.java
@@ -41,16 +41,12 @@ import java.util.Map;
  * methods; all-false for {@code prototype}).
  */
 class JsObjectConstructor extends JsFunction {
-
-    static final JsObjectConstructor INSTANCE = new JsObjectConstructor();
-
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
 
-    private JsObjectConstructor() {
+    JsObjectConstructor() {
         this.name = "Object";
         this.length = 1;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
@@ -116,12 +112,6 @@ class JsObjectConstructor extends JsFunction {
     @Override
     public boolean isConstructable() {
         return true;
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     // -------------------------------------------------------------------------

--- a/karate-js/src/main/java/io/karatelabs/js/JsObjectPrototype.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsObjectPrototype.java
@@ -133,7 +133,9 @@ class JsObjectPrototype extends Prototype {
         desc.put(isGetter ? "get" : "set", callable);
         desc.put("enumerable", true);
         desc.put("configurable", true);
-        JsObjectConstructor.INSTANCE.defineProperty(context, new Object[]{thisObj, key, desc});
+        JsObjectConstructor objectConstructor =
+                (JsObjectConstructor) context.getEngine().builtinConstructor("Object");
+        objectConstructor.defineProperty(context, new Object[]{thisObj, key, desc});
         return Terms.UNDEFINED;
     }
 

--- a/karate-js/src/main/java/io/karatelabs/js/JsRegexConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsRegexConstructor.java
@@ -31,27 +31,17 @@ package io.karatelabs.js;
  * by {@code new RegExp(pattern, flags)} and {@code /foo/} literals.
  */
 class JsRegexConstructor extends JsFunction {
-
-    static final JsRegexConstructor INSTANCE = new JsRegexConstructor();
-
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
 
-    private JsRegexConstructor() {
+    JsRegexConstructor() {
         this.name = "RegExp";
         this.length = 2;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
         defineOwn("escape", new JsBuiltinMethod("escape", 1, (JsInvokable) this::escape), METHOD_ATTRS);
         defineOwn("prototype", JsRegexPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsRegexPrototype.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsRegexPrototype.java
@@ -61,7 +61,7 @@ class JsRegexPrototype extends Prototype {
         installFlagAccessor("dotAll", Terms.UNDEFINED, r -> r.flags.contains("s"));
         installFlagAccessor("sticky", Terms.UNDEFINED, r -> r.flags.contains("y"));
         installFlagAccessor("unicode", Terms.UNDEFINED, r -> r.flags.contains("u"));
-        installLazy("constructor", () -> JsRegexConstructor.INSTANCE);
+        installConstructor("RegExp");
     }
 
     // Spec §22.2.6.4 etc. shared shape: TypeError on non-object receiver,

--- a/karate-js/src/main/java/io/karatelabs/js/JsSetConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsSetConstructor.java
@@ -30,24 +30,14 @@ package io.karatelabs.js;
  * {@code Set.prototype.add} is honored.
  */
 class JsSetConstructor extends JsFunction {
-
-    static final JsSetConstructor INSTANCE = new JsSetConstructor();
-
-    private JsSetConstructor() {
+    JsSetConstructor() {
         this.name = "Set";
         // length=0 — Set() takes optional iterable; spec arity is 0.
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
         defineOwn("prototype", JsSetPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/JsStringConstructor.java
+++ b/karate-js/src/main/java/io/karatelabs/js/JsStringConstructor.java
@@ -33,16 +33,12 @@ package io.karatelabs.js;
  * the {@code prototype} slot per spec.
  */
 class JsStringConstructor extends JsFunction {
-
-    static final JsStringConstructor INSTANCE = new JsStringConstructor();
-
     private static final byte METHOD_ATTRS = WRITABLE | CONFIGURABLE | PropertySlot.INTRINSIC;
 
-    private JsStringConstructor() {
+    JsStringConstructor() {
         this.name = "String";
         this.length = 1;
         installIntrinsics();
-        registerForEngineReset();
     }
 
     private void installIntrinsics() {
@@ -50,12 +46,6 @@ class JsStringConstructor extends JsFunction {
         defineOwn("fromCodePoint", new JsBuiltinMethod("fromCodePoint", 1, (JsInvokable) this::fromCodePoint), METHOD_ATTRS);
         defineOwn("raw", new JsBuiltinMethod("raw", 1, this::raw), METHOD_ATTRS);
         defineOwn("prototype", JsStringPrototype.INSTANCE, PropertySlot.INTRINSIC);
-    }
-
-    @Override
-    protected void clearEngineState() {
-        super.clearEngineState();
-        installIntrinsics();
     }
 
     @Override

--- a/karate-js/src/main/java/io/karatelabs/js/PropertySlot.java
+++ b/karate-js/src/main/java/io/karatelabs/js/PropertySlot.java
@@ -49,7 +49,8 @@ sealed abstract class PropertySlot permits DataSlot, AccessorSlot {
     static final byte ENUMERABLE = 0b0010;
     /** Bit 2: configurable. */
     static final byte CONFIGURABLE = 0b0100;
-    /** Bit 3: install-time intrinsic — survives {@code clearEngineState}. */
+    /** Bit 3: install-time intrinsic (vs user-set). Informational — used by
+     *  strict-mode checks and introspection, not by any reset machinery. */
     static final byte INTRINSIC = 0b1000;
     /** Default for newly-created own properties: W|E|C all-true, not intrinsic. */
     static final byte ATTRS_DEFAULT = WRITABLE | ENUMERABLE | CONFIGURABLE;

--- a/karate-js/src/main/java/io/karatelabs/js/Prototype.java
+++ b/karate-js/src/main/java/io/karatelabs/js/Prototype.java
@@ -25,9 +25,7 @@ package io.karatelabs.js;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
 /**
@@ -36,15 +34,16 @@ import java.util.function.Supplier;
  * <ul>
  *   <li>{@link #builtins} — install-time map populated by the subclass
  *       constructor via {@link #install(String, int, JsCallable)} /
- *       {@link #install(String, Object)}. Survives across Engine sessions
- *       (re-built only on first class-load); no per-Engine reset needed.</li>
- *   <li>{@link #userProps} — user-added entries via {@code putMember}; cleared
- *       per-Engine via {@link #clearAllUserProps}. Wins over {@link #builtins}
- *       per spec ({@code Array.prototype} methods are configurable + writable).
- *       Each entry is a {@link PropertySlot} ({@link DataSlot} for plain values,
- *       {@link AccessorSlot} for accessor descriptors); the slot's
- *       {@link PropertySlot#tombstoned} flag shadows a built-in deleted via
- *       {@code delete Foo.prototype.bar}.</li>
+ *       {@link #install(String, Object)}. Shared JVM-wide and immutable
+ *       post-construction; safe under concurrent engines.</li>
+ *   <li>per-Engine user props ({@link #userProps()}) — user-added entries via
+ *       {@code putMember}, stored on the current {@link Engine} so prototype
+ *       mutations are invisible to (and indestructible by) other engines.
+ *       Wins over {@link #builtins} per spec ({@code Array.prototype} methods
+ *       are configurable + writable). Each entry is a {@link PropertySlot}
+ *       ({@link DataSlot} for plain values, {@link AccessorSlot} for accessor
+ *       descriptors); the slot's {@link PropertySlot#tombstoned} flag shadows
+ *       a built-in deleted via {@code delete Foo.prototype.bar}.</li>
  * </ul>
  * <p>
  * Method identity ({@code Foo.prototype.bar === Foo.prototype.bar}) follows
@@ -54,43 +53,82 @@ import java.util.function.Supplier;
 abstract class Prototype implements ObjectLike {
 
     /**
-     * Built-in prototype singletons register themselves here at construction.
-     * {@link Engine#Engine()} walks this list to clear each one's user-side
-     * state ({@link #userProps}) so prototype mutations inside one Engine
-     * instance don't bleed into the next. Required for test262 isolation.
+     * JVM-wide monotonic fast-path flag: false until ANY engine installs a
+     * user property on ANY built-in prototype. While false — the
+     * overwhelmingly common case, since real scripts rarely polyfill
+     * built-in prototypes — property lookups skip per-Engine overlay
+     * resolution entirely, so the hot path pays no ThreadLocal read.
+     * Never reset: once some engine polyfills, every engine pays the
+     * (small) overlay-lookup cost for the rest of the JVM's life.
      */
-    private static final List<Prototype> ALL = new CopyOnWriteArrayList<>();
+    private static volatile boolean anyUserProps = false;
 
     /**
-     * Per-Engine flag: set when a canonical numeric property is installed on
-     * any prototype's userProps via {@link #putMember} or
-     * {@link #defineOwnAccessor}. Lets {@code Array.prototype.*} iteration
-     * helpers ({@code every} / {@code map} / {@code forEach} / …) skip the
-     * full HasProperty proto-walk per element on the hot path: when this is
-     * false (the common case — no user code did
-     * {@code Array.prototype[i] = …} or {@code Object.prototype[i] = …}),
-     * the spec's HasProperty reduces to an own-only check.
-     * <p>
-     * Monotonic within an Engine (we don't track when it stops being polluted
-     * — once true, fast path is bypassed for the remainder of the session).
-     * Reset to false in {@link #clearAllUserProps} so the next Engine starts
-     * clean — required for test262 isolation.
+     * Engineless fallback for user-prop writes issued outside any JS
+     * execution (no {@link Engine#current()}); hosts virtually never do
+     * this. Shared JVM-wide like the pre-overlay storage was.
      */
-    private static volatile boolean numericPropPolluted = false;
+    private Map<String, PropertySlot> orphanUserProps;
 
-    /** True iff any user code installed a canonical numeric key on a prototype
-     *  in this Engine session. See {@link #numericPropPolluted}. */
+    /** Engineless counterpart of {@link Engine#numericPropPolluted}. */
+    private static volatile boolean orphanNumericPropPolluted = false;
+
+    /**
+     * True iff user code installed a canonical numeric key on a built-in
+     * prototype in the current Engine session. Lets {@code Array.prototype.*}
+     * iteration helpers ({@code every} / {@code map} / {@code forEach} / …)
+     * skip the full HasProperty proto-walk per element on the hot path: when
+     * false (the common case — no user code did {@code Array.prototype[i] = …}
+     * or {@code Object.prototype[i] = …}), the spec's HasProperty reduces to
+     * an own-only check. Monotonic within an Engine.
+     */
     static boolean isNumericPropPolluted() {
-        return numericPropPolluted;
+        if (orphanNumericPropPolluted) {
+            return true;
+        }
+        Engine engine = Engine.current();
+        return engine != null && engine.numericPropPolluted;
     }
 
-    static void clearAllUserProps() {
-        for (Prototype p : ALL) {
-            if (p.userProps != null) {
-                p.userProps.clear();
-            }
+    private static void markNumericPolluted() {
+        Engine engine = Engine.current();
+        if (engine != null) {
+            engine.numericPropPolluted = true;
+        } else {
+            orphanNumericPropPolluted = true;
         }
-        numericPropPolluted = false;
+    }
+
+    /**
+     * The current Engine's user-property overlay for this prototype — null
+     * when none. Built-in prototypes are JVM-wide singletons, but user
+     * mutations ({@code Array.prototype.foo = …}) are per-Engine state: they
+     * live on the Engine (see {@link Engine#protoUserProps}) and are resolved
+     * through the thread's current engine, so one engine's pollution is
+     * invisible to every other engine and no cross-engine reset is needed.
+     */
+    private Map<String, PropertySlot> userProps() {
+        if (!anyUserProps) {
+            return null;
+        }
+        Engine engine = Engine.current();
+        if (engine != null) {
+            return engine.protoUserProps(this, false);
+        }
+        return orphanUserProps;
+    }
+
+    /** Same resolution as {@link #userProps()} but creates the overlay on demand. */
+    private Map<String, PropertySlot> userPropsForWrite() {
+        anyUserProps = true;
+        Engine engine = Engine.current();
+        if (engine != null) {
+            return engine.protoUserProps(this, true);
+        }
+        if (orphanUserProps == null) {
+            orphanUserProps = new LinkedHashMap<>();
+        }
+        return orphanUserProps;
     }
 
     /** Canonical-integer key check for the {@link #numericPropPolluted}
@@ -108,15 +146,17 @@ abstract class Prototype implements ObjectLike {
     }
 
     private final Prototype __proto__;
-    private Map<String, PropertySlot> userProps;
     /** Install-time built-in members. Populated by subclass constructors via
-     *  {@link #install} helpers. Treated as immutable post-construction —
-     *  user mutations land in {@link #userProps} and shadow these. */
+     *  {@link #install} helpers. Immutable post-construction — user mutations
+     *  land in the per-Engine overlay ({@link #userProps()}) and shadow
+     *  these. Structural immutability is load-bearing: the map is read
+     *  concurrently by every engine on every thread, with no per-Engine
+     *  reset; {@link LazyRef} / {@link ConstructorRef} entries resolve
+     *  without writing back. */
     private final Map<String, Object> builtins = new LinkedHashMap<>();
 
     Prototype(Prototype __proto__) {
         this.__proto__ = __proto__;
-        ALL.add(this);
     }
 
     @Override
@@ -126,10 +166,8 @@ abstract class Prototype implements ObjectLike {
 
     @Override
     public void putMember(String name, Object value) {
-        if (userProps == null) {
-            userProps = new LinkedHashMap<>();
-        }
-        if (isCanonicalNumericKey(name)) numericPropPolluted = true;
+        Map<String, PropertySlot> userProps = userPropsForWrite();
+        if (isCanonicalNumericKey(name)) markNumericPolluted();
         PropertySlot existing = userProps.get(name);
         if (existing instanceof DataSlot ds) {
             ds.value = value;
@@ -142,6 +180,7 @@ abstract class Prototype implements ObjectLike {
 
     @Override
     public void removeMember(String name) {
+        Map<String, PropertySlot> userProps = userProps();
         PropertySlot existing = userProps == null ? null : userProps.get(name);
         if (existing != null && existing.tombstoned) {
             return;
@@ -170,12 +209,9 @@ abstract class Prototype implements ObjectLike {
                 ds.value = null;
                 ds.tombstoned = true;
             } else {
-                if (userProps == null) {
-                    userProps = new LinkedHashMap<>();
-                }
                 DataSlot ts = new DataSlot(name);
                 ts.tombstoned = true;
-                userProps.put(name, ts);
+                userPropsForWrite().put(name, ts);
             }
         } else {
             // No built-in to shadow; just drop the user slot entirely.
@@ -185,6 +221,7 @@ abstract class Prototype implements ObjectLike {
 
     @Override
     public Map<String, Object> toMap() {
+        Map<String, PropertySlot> userProps = userProps();
         if (userProps == null || userProps.isEmpty()) return Collections.emptyMap();
         Map<String, Object> view = new LinkedHashMap<>(userProps.size());
         for (PropertySlot s : userProps.values()) {
@@ -196,18 +233,20 @@ abstract class Prototype implements ObjectLike {
 
     @Override
     public final Object getMember(String name) {
+        Map<String, PropertySlot> userProps = userProps();
         PropertySlot s = userProps == null ? null : userProps.get(name);
         if (s != null) {
             if (s.tombstoned) return walkProto(name);
             return s instanceof DataSlot ds ? ds.value : null;
         }
-        Object builtin = resolveBuiltin(name);
+        Object builtin = resolveBuiltin(name, null);
         if (builtin != null) return builtin;
         return walkProto(name);
     }
 
     @Override
     public Object getMember(String name, Object receiver, CoreContext ctx) {
+        Map<String, PropertySlot> userProps = userProps();
         PropertySlot s = userProps == null ? null : userProps.get(name);
         if (s != null) {
             if (s.tombstoned) {
@@ -215,7 +254,7 @@ abstract class Prototype implements ObjectLike {
             }
             return s.read(receiver, ctx);
         }
-        Object builtin = resolveBuiltin(name);
+        Object builtin = resolveBuiltin(name, ctx);
         // Built-in accessor slot (installed via {@link #installAccessor}) —
         // dispatch through {@link AccessorSlot#read} so the getter sees the
         // user receiver and the prototype-self sentinel branch fires for
@@ -229,20 +268,27 @@ abstract class Prototype implements ObjectLike {
         return __proto__ == null ? null : __proto__.getMember(name);
     }
 
-    private Object resolveBuiltin(String name) {
+    private Object resolveBuiltin(String name, CoreContext ctx) {
         Object result = builtins.get(name);
         if (result instanceof LazyRef lr) {
-            // Cross-reference (e.g. `constructor` → JsXxxConstructor.INSTANCE)
-            // — resolved on first access since both singletons must exist
-            // by then. Cache the resolution to drop the indirection.
-            result = lr.supplier.get();
-            builtins.put(name, result);
+            // Lazily-allocated built-in (e.g. JsBuiltinMethod wrapper) —
+            // cached inside the LazyRef itself, NOT written back into
+            // builtins, so the shared map stays structurally immutable
+            // under concurrent readers.
+            return lr.resolve();
+        }
+        if (result instanceof ConstructorRef cr) {
+            // `constructor` cross-reference — each Engine has its own
+            // constructor instances, so resolve per access against the
+            // reading engine and never cache.
+            Engine engine = ctx != null ? ctx.getEngine() : Engine.current();
+            return engine == null ? null : engine.builtinConstructor(cr.globalName);
         }
         return result;
     }
 
     /** Installs (or updates) a data descriptor at {@code name} in
-     *  {@link #userProps}. Used by {@code Object.defineProperty} when the
+     *  the per-Engine user props. Used by {@code Object.defineProperty} when the
      *  target is a prototype with a data descriptor (e.g.
      *  {@code Object.defineProperty(Function.prototype, "prop",
      *  {value: 1001, enumerable: false, configurable: true})} — the attrs
@@ -252,10 +298,8 @@ abstract class Prototype implements ObjectLike {
      *  through to {@link #putMember} which carries no attrs and leaves the
      *  slot at {@link PropertySlot#ATTRS_DEFAULT} (W|E|C). */
     final void defineOwn(String name, Object value, byte attrs) {
-        if (userProps == null) {
-            userProps = new LinkedHashMap<>();
-        }
-        if (isCanonicalNumericKey(name)) numericPropPolluted = true;
+        Map<String, PropertySlot> userProps = userPropsForWrite();
+        if (isCanonicalNumericKey(name)) markNumericPolluted();
         PropertySlot existing = userProps.get(name);
         DataSlot s;
         if (existing instanceof DataSlot ds) {
@@ -271,14 +315,12 @@ abstract class Prototype implements ObjectLike {
     }
 
     /** Installs (or updates) an accessor descriptor at {@code name} in
-     *  {@link #userProps}. Used by {@code Object.defineProperty} when the
+     *  the per-Engine user props. Used by {@code Object.defineProperty} when the
      *  target is a prototype (e.g.
      *  {@code Object.defineProperty(String.prototype, "x", {get: …})}). */
     final void defineOwnAccessor(String name, JsCallable getter, JsCallable setter, byte attrs) {
-        if (userProps == null) {
-            userProps = new LinkedHashMap<>();
-        }
-        if (isCanonicalNumericKey(name)) numericPropPolluted = true;
+        Map<String, PropertySlot> userProps = userPropsForWrite();
+        if (isCanonicalNumericKey(name)) markNumericPolluted();
         PropertySlot existing = userProps.get(name);
         AccessorSlot s;
         if (existing instanceof AccessorSlot as) {
@@ -296,13 +338,14 @@ abstract class Prototype implements ObjectLike {
     /** Returns the own slot at {@code name} (data or accessor) when one is
      *  installed via {@link #defineOwnAccessor} / {@link #putMember} or
      *  via the install-time {@link #installAccessor}, or {@code null}
-     *  when absent or tombstoned. User slots in {@link #userProps} shadow
+     *  when absent or tombstoned. User slots in the per-Engine user props shadow
      *  built-in slots in {@link #builtins} — same precedence as
      *  {@link #getMember}. Mirrors
      *  {@link JsObject#getOwnSlot(String)} / {@link JsArray#getOwnSlot(String)}
      *  so {@link PropertyAccess#findAccessorInChain} and descriptor-inspection
      *  paths can use a single signature across all three storage shapes. */
     final PropertySlot getOwnSlot(String name) {
+        Map<String, PropertySlot> userProps = userProps();
         if (userProps != null) {
             PropertySlot s = userProps.get(name);
             if (s != null) return s.tombstoned ? null : s;
@@ -323,27 +366,18 @@ abstract class Prototype implements ObjectLike {
         builtins.put(name, new LazyRef(() -> new JsBuiltinMethod(name, length, delegate)));
     }
 
-    /** Install a built-in data slot (e.g. {@code constructor} pointer). */
+    /** Install a built-in data slot (e.g. the {@code name} string on an
+     *  error prototype). For {@code constructor} back-references use
+     *  {@link #installConstructor} — constructor instances are per-Engine. */
     protected final void install(String name, Object value) {
         builtins.put(name, value);
-    }
-
-    /** Install a built-in data slot whose value is resolved lazily on first
-     *  access. Use for cross-references between prototypes and constructors
-     *  (e.g. {@code Function.prototype.constructor} → {@code JsFunctionConstructor.INSTANCE})
-     *  where the {@code INSTANCE} field is still being initialized at the
-     *  moment of install but will be live by the time JS code reads it. */
-    protected final void installLazy(String name, Supplier<Object> resolver) {
-        builtins.put(name, new LazyRef(resolver));
     }
 
     /** Install a built-in accessor descriptor at {@code name}. Spec
      *  prototype getters (e.g. {@code RegExp.prototype.source},
      *  {@code Map.prototype.size}) live here; user-defined accessors via
      *  {@code Object.defineProperty} go through {@link #defineOwnAccessor}
-     *  into {@link #userProps} instead. {@link #builtins} survives
-     *  per-Engine reset, which is required so the spec accessors don't
-     *  vanish between {@code new Engine()} cycles. The
+     *  into the per-Engine user props instead. The
      *  {@link AccessorSlot} is materialized eagerly because lambdas / the
      *  spec sentinel closures don't need the static-init deferral that
      *  {@link #install(String, int, JsCallable)}'s LazyRef pattern protects
@@ -356,17 +390,59 @@ abstract class Prototype implements ObjectLike {
         builtins.put(name, s);
     }
 
-    private record LazyRef(Supplier<Object> supplier) {
+    /** Lazily-resolved built-in entry. Caches its own resolution (instead of
+     *  writing back into {@link #builtins}) so the shared builtins map never
+     *  structurally mutates after construction — it is read concurrently by
+     *  every engine on every thread. The synchronized resolve keeps method
+     *  identity ({@code Foo.prototype.bar === Foo.prototype.bar}) stable
+     *  JVM-wide even when two engines race the first access. */
+    private static final class LazyRef {
+        private final Supplier<Object> supplier;
+        private volatile Object resolved;
+
+        LazyRef(Supplier<Object> supplier) {
+            this.supplier = supplier;
+        }
+
+        Object resolve() {
+            Object result = resolved;
+            if (result == null) {
+                synchronized (this) {
+                    result = resolved;
+                    if (result == null) {
+                        result = supplier.get();
+                        resolved = result;
+                    }
+                }
+            }
+            return result;
+        }
+    }
+
+    /** Marker for the {@code constructor} cross-reference on a built-in
+     *  prototype. Resolved per access against the reading Engine's
+     *  constructor registry (see {@link Engine#builtinConstructor}) and
+     *  never cached — constructor instances are per-Engine, so caching one
+     *  engine's instance in the shared builtins map would leak it to all. */
+    private record ConstructorRef(String globalName) {
+    }
+
+    /** Install the spec {@code constructor} back-reference, pointing at the
+     *  built-in constructor registered under {@code globalName} ("Array",
+     *  "TypeError", …) in each Engine. */
+    protected final void installConstructor(String globalName) {
+        builtins.put("constructor", new ConstructorRef(globalName));
     }
 
     /**
      * Spec attribute byte for an own property. Reads the per-property attrs
-     * stored on the slot when one exists in {@link #userProps}; otherwise
+     * stored on the slot when one exists in the per-Engine user props; otherwise
      * falls back to the class default returned by {@link #defaultAttrs(String)}
      * (built-in methods carry {@code {writable: true, enumerable: false,
      * configurable: true}} on every standard prototype).
      */
     public final byte getOwnAttrs(String name) {
+        Map<String, PropertySlot> userProps = userProps();
         PropertySlot s = userProps == null ? null : userProps.get(name);
         if (s != null && !s.tombstoned) {
             return s.attrs;
@@ -394,6 +470,7 @@ abstract class Prototype implements ObjectLike {
      */
     @Override
     public boolean isOwnProperty(String name) {
+        Map<String, PropertySlot> userProps = userProps();
         PropertySlot s = userProps == null ? null : userProps.get(name);
         if (s != null) {
             return !s.tombstoned;

--- a/karate-js/src/test/java/io/karatelabs/js/EngineConcurrencyTest.java
+++ b/karate-js/src/test/java/io/karatelabs/js/EngineConcurrencyTest.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 Karate Labs Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.karatelabs.js;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Engines on different threads must not interfere with each other.
+ * <p>
+ * Built-in constructors are per-Engine instances and the shared prototype
+ * singletons keep all per-Engine mutable state in Engine-owned overlays, so
+ * constructing an Engine on one thread must leave engines mid-evaluation on
+ * other threads fully functional. These tests pin that contract — the
+ * historical clear-on-construct reset wiped JVM-wide singleton state and
+ * produced intermittent "Object.keys is not a function" /
+ * "Array.isArray is not a function" failures in parallel suite runs.
+ */
+class EngineConcurrencyTest {
+
+    // exercises Object.keys, Array.isArray and an Object static via a bound
+    // variable — the shapes reported to break under parallel suite runs
+    static final String SCRIPT = "var queryObj = { a: 1, b: 2 };"
+            + " var keys = Object.keys(queryObj);"
+            + " var flag = Array.isArray([1, 2, 3]);"
+            + " keys.length + (flag ? 10 : 0)";
+
+    static void assertResult(Object result) {
+        if (!(result instanceof Number n) || n.intValue() != 12) {
+            throw new AssertionError("expected 12 but got: " + result);
+        }
+    }
+
+    @Test
+    @Timeout(120)
+    void parallelEnginesEvalBuiltins() throws Exception {
+        int threadCount = 8;
+        int iterations = 500;
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+        List<Thread> threads = new ArrayList<>();
+        for (int t = 0; t < threadCount; t++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    // same shape as a parallel suite run: each scenario gets a
+                    // fresh Engine, many scenarios in flight at once
+                    for (int i = 0; i < iterations; i++) {
+                        Engine engine = new Engine();
+                        assertResult(engine.eval(SCRIPT));
+                    }
+                } catch (Throwable e) {
+                    failures.add(e);
+                }
+            }, "engine-concurrency-" + t);
+            thread.setDaemon(true);
+            threads.add(thread);
+            thread.start();
+        }
+        for (Thread thread : threads) {
+            thread.join(60000);
+        }
+        assertTrue(failures.isEmpty(), () -> failures.size() + " of " + threadCount
+                + " threads failed, first failure: " + failures.get(0));
+    }
+
+    @Test
+    @Timeout(120)
+    void engineConstructionDoesNotPoisonRunningEngine() throws Exception {
+        int iterations = 2000;
+        AtomicBoolean done = new AtomicBoolean();
+        List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+        // worker holds ONE engine and just evaluates — it never touches
+        // another Engine, so any failure here is cross-thread interference
+        Thread worker = new Thread(() -> {
+            try {
+                Engine engine = new Engine();
+                for (int i = 0; i < iterations; i++) {
+                    assertResult(engine.eval(SCRIPT));
+                }
+            } catch (Throwable e) {
+                failures.add(e);
+            } finally {
+                done.set(true);
+            }
+        }, "engine-concurrency-worker");
+        worker.setDaemon(true);
+        worker.start();
+        // churn Engine construction (per-scenario engines, match Operations,
+        // TagSelector evals all do this in a parallel suite run)
+        while (!done.get()) {
+            new Engine();
+        }
+        worker.join(60000);
+        assertTrue(failures.isEmpty(), () -> "running engine broke during concurrent"
+                + " Engine construction: " + failures.get(0));
+    }
+
+}

--- a/karate-js/src/test/java/io/karatelabs/js/EngineTest.java
+++ b/karate-js/src/test/java/io/karatelabs/js/EngineTest.java
@@ -1032,10 +1032,10 @@ class EngineTest {
 
     @Test
     void testBuiltinConstructorStateResetBetweenEngines() {
-        // Built-in constructor singletons (JsNumberConstructor.INSTANCE etc.) live for the
-        // JVM's lifetime. Without per-Engine state reset, a user-set property or a delete
-        // on one Engine would leak into the next — propertyHelper.js does exactly this in
-        // a tight loop. Cover the user-set / delete / configurability-flip paths.
+        // Built-in constructors are per-Engine instances, so a user-set property or a
+        // delete on one Engine must never be visible in the next — propertyHelper.js
+        // does exactly this in a tight loop. Cover the user-set / delete /
+        // configurability-flip paths.
         Engine e1 = new Engine();
         e1.eval("Number.foo = 123");
         e1.eval("delete Number.isFinite");


### PR DESCRIPTION
## Background

We observed tests running perfectly under a single thread but when bumping up the thread count (e.g. 4 concurrent threads) we started to see strange errors like `Error: expression: Object.keys(queryObj) - TypeError: Object.keys is not a function` and `Error: TypeError: Array.isArray is not a function`. I fed this basic info into Claude and it identified / implemented this fix 100% autonomously. We're now able to run our full test suite without error.

## Description

Parallel suite runs (4+ threads) intermittently failed with errors like "TypeError: Object.keys is not a function" / "Array.isArray is not a function". Root cause: built-in constructor singletons and prototype singletons were JVM-wide, and the Engine constructor reset their per-Engine mutable state globally (clearAllUserProps / clearAllEngineState). The reset was clear-then-reinstall, so any thread constructing an Engine briefly removed Object.keys etc. from under engines mid-evaluation on other threads — and the unsynchronized LinkedHashMaps raced besides. karate-core constructs engines constantly (per scenario, per match operation), making parallel runs trip this reliably.

Dissolve the shared-mutable-state problem instead of guarding it:

- Built-in constructors (Object, Array, ..., the 8 Error types) become per-Engine instances, created lazily by ContextRoot.builtinConstructor and cached in the engine's bindings — the pattern JsMath already used. User mutations / deletes / freezes on them ride the ordinary JsObject machinery and are naturally engine-isolated.
- Prototype singletons stay JVM-wide but keep user props (polyfills, tombstones) in Engine-owned overlays, resolved through an eval-scoped ThreadLocal current-engine handle (established in Engine.evalInternal / evalRaw and at the JsFunctionNode.call host boundary). A monotonic fast-path flag keeps the common no-polyfill case free of ThreadLocal reads. The shared builtins install maps are immutable post-construction; lazy entries cache in-place and constructor back-references resolve per access against the reading engine.
- Delete the reset machinery outright: ENGINE_RESET_LIST, clearAllEngineState, clearEngineState overrides, clearAllUserProps. The race is unrepresentable rather than guarded. numericPropPolluted moves from a static to an Engine field.

EngineConcurrencyTest pins the contract: parallel engines evaluating builtins, and a running engine surviving concurrent Engine construction on another thread. Both failed before this change (7-of-8 threads, 4ms to first failure) and pass stably now.

karate-js: 1172 tests green; karate-core: 2286 green. Benchmark: eval throughput unchanged, engine instantiation 8.83µs -> 0.71µs (reset walk gone).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [ ] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [x] I have updated documentation as needed
