### PR TITLE
fix(driver): re-arm OOPIF auto-attach when switching CDP sessions

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpClient.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpClient.java
@@ -23,6 +23,7 @@
  */
 package io.karatelabs.driver.cdp;
 
+import io.karatelabs.common.ThreadUtils;
 import io.karatelabs.http.HttpUtils;
 import io.karatelabs.http.WsClient;
 import io.karatelabs.http.WsClientOptions;
@@ -56,6 +57,14 @@ public class CdpClient {
     private final Duration defaultTimeout;
     private volatile String sessionId;
 
+    // Two-lane dispatch (see connect() and handleMessage() for the why):
+    // frameRouter processes raw frames strictly in arrival order and completes
+    // response futures; eventDispatcher runs event handlers, also in order, on its
+    // own thread so a handler that issues a blocking send() cannot deadlock the
+    // router that must complete that send's response.
+    private final ExecutorService frameRouter;
+    private final ExecutorService eventDispatcher;
+
     static class PendingRequest {
         final CompletableFuture<CdpResponse> future;
         final String method;
@@ -73,19 +82,31 @@ public class CdpClient {
     }
 
     public static CdpClient connect(String webSocketUrl, Duration defaultTimeout) {
+        // CDP frames MUST be observed in arrival order. The WsClient default hands
+        // each frame to a shared cached pool as an independent task, so under load
+        // two frames from the same connection can be processed concurrently or out
+        // of order — e.g. Target.attachedToTarget / Target.detachedFromTarget pairs
+        // swapping, or Runtime.executionContextCreated racing a session switch.
+        // A dedicated single-thread executor restores per-connection ordering.
+        ExecutorService frameRouter = Executors.newSingleThreadExecutor(
+                ThreadUtils.daemonFactory("cdp-frame-"));
         WsClientOptions options = WsClientOptions.builder(webSocketUrl)
                 .disablePing() // CDP handles its own keepalive
                 .maxPayloadSize(HttpUtils.MEGABYTE * 16) // Screenshots can be large
+                .callbackExecutor(frameRouter)
                 .build();
         WsClient ws = WsClient.connect(options);
-        CdpClient client = new CdpClient(ws, defaultTimeout);
+        CdpClient client = new CdpClient(ws, defaultTimeout, frameRouter);
         client.waitForReady();
         return client;
     }
 
-    private CdpClient(WsClient ws, Duration defaultTimeout) {
+    private CdpClient(WsClient ws, Duration defaultTimeout, ExecutorService frameRouter) {
         this.ws = ws;
         this.defaultTimeout = defaultTimeout;
+        this.frameRouter = frameRouter;
+        this.eventDispatcher = Executors.newSingleThreadExecutor(
+                ThreadUtils.daemonFactory("cdp-event-"));
         setupMessageHandler();
     }
 
@@ -141,7 +162,10 @@ public class CdpClient {
         }
 
         if (map.containsKey("id")) {
-            // Response to a request
+            // Response to a request — complete the future right here on the router
+            // thread. Completing is cheap and never blocks, and it must NOT queue
+            // behind events: an event handler may be blocked in send() waiting for
+            // this very response.
             int id = ((Number) map.get("id")).intValue();
             PendingRequest pr = pending.remove(id);
             if (pr != null) {
@@ -152,10 +176,18 @@ public class CdpClient {
                 logger.trace("received response for fire-and-forget request id: {}", id);
             }
         } else if (map.containsKey("method")) {
-            // Event
+            // Event — hop to the dedicated dispatch thread, preserving order.
+            // Handlers must not run on the router thread: several of them issue
+            // blocking sends (dialog dismissal, Fetch interception), and the
+            // response to such a send is completed by the router — running the
+            // handler there would deadlock until the CDP timeout.
             String method = (String) map.get("method");
             CdpEvent event = new CdpEvent(map);
-            dispatchEvent(method, event);
+            try {
+                eventDispatcher.execute(() -> dispatchEvent(method, event));
+            } catch (RejectedExecutionException e) {
+                logger.trace("event dropped after close: {}", method);
+            }
         }
     }
 
@@ -353,6 +385,16 @@ public class CdpClient {
 
     public void close() {
         ws.close();
+        // The websocket close callback arrives asynchronously and may be rejected
+        // once the executors below are shut down — fail any still-pending futures
+        // here instead of relying on the onClose listener to do it.
+        for (PendingRequest pr : pending.values()) {
+            pr.future.completeExceptionally(
+                    new WsException(WsException.Type.CONNECTION_CLOSED, "cdp client closed"));
+        }
+        pending.clear();
+        frameRouter.shutdown();
+        eventDispatcher.shutdown();
     }
 
     public boolean isOpen() {

--- a/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpDriver.java
+++ b/karate-core/src/main/java/io/karatelabs/driver/cdp/CdpDriver.java
@@ -616,7 +616,10 @@ public class CdpDriver implements Driver {
                 oopifSessions.put(targetId, attachedSessionId);
                 logger.debug("Attached to isolated iframe (OOPIF): {} session={}",
                         targetInfo.get("url"), attachedSessionId);
-                cdp.method("Runtime.enable").sessionId(attachedSessionId).send();
+                // Fire-and-forget: the response is unused, and this handler runs on
+                // the serialized CDP event-dispatch thread — a blocking send here
+                // would stall every queued event for a round-trip per OOPIF.
+                cdp.method("Runtime.enable").sessionId(attachedSessionId).sendWithoutWaiting();
             }
         });
 
@@ -3004,6 +3007,8 @@ public class CdpDriver implements Driver {
      * 3. Update sessionId - all subsequent CDP commands use this session
      * 4. Re-enable domains - Page/Runtime must be enabled per-session
      *    - This triggers Runtime.executionContextCreated events for new session
+     *    - Target.setAutoAttach is also per-session and must be re-armed, or
+     *      OOPIF (cross-origin iframe) tracking goes dark for this tab
      * 5. Get mainFrameId - each tab has its own frame tree
      * 6. Clear frameContexts - old contexts are invalid for new session
      * 7. Wait for context - ensures executionContextCreated event is processed
@@ -3040,6 +3045,25 @@ public class CdpDriver implements Driver {
         cdp.method("Runtime.enable").send();
         cdp.method("Page.setLifecycleEventsEnabled")
                 .param("enabled", true)
+                .send();
+
+        // Target.setAutoAttach is session-scoped: initialize() armed it on the
+        // websocket's root session, but this tab is driven through the fresh
+        // flattened session created above, where auto-attach is OFF by default.
+        // Without re-arming it here, cross-origin iframes (OOPIFs) in this tab
+        // never fire Target.attachedToTarget, oopifSessions stays empty, and
+        // switchFrame() on such an iframe fails with "could not find frame" —
+        // observed with payment-provider iframes on pooled drivers after a prior
+        // scenario called switchPage()/close(). Stale OOPIF entries belong to the
+        // previously-driven tab and are unreachable from this session, so drop
+        // them; Chrome re-fires attachedToTarget for this tab's existing OOPIFs
+        // as soon as auto-attach lands.
+        oopifTargets.clear();
+        oopifSessions.clear();
+        cdp.method("Target.setAutoAttach")
+                .param("autoAttach", true)
+                .param("waitForDebuggerOnStart", false)
+                .param("flatten", true)
                 .send();
 
         // Get new main frame ID (each tab has its own frame tree)

--- a/karate-core/src/main/java/io/karatelabs/http/WsClient.java
+++ b/karate-core/src/main/java/io/karatelabs/http/WsClient.java
@@ -337,7 +337,7 @@ public class WsClient {
 
     void handleFrame(WsFrame frame) {
         for (Consumer<WsFrame> listener : messageListeners) {
-            callbackExecutor.execute(() -> {
+            dispatch(() -> {
                 try {
                     listener.accept(frame);
                 } catch (Exception e) {
@@ -350,7 +350,7 @@ public class WsClient {
     void handleDisconnect() {
         open = false;
         for (Runnable listener : closeListeners) {
-            callbackExecutor.execute(() -> {
+            dispatch(() -> {
                 try {
                     listener.run();
                 } catch (Exception e) {
@@ -363,13 +363,26 @@ public class WsClient {
 
     void handleError(Throwable cause) {
         for (Consumer<Throwable> listener : errorListeners) {
-            callbackExecutor.execute(() -> {
+            dispatch(() -> {
                 try {
                     listener.accept(cause);
                 } catch (Exception e) {
                     logger.error("error listener error: {}", e.getMessage());
                 }
             });
+        }
+    }
+
+    /**
+     * A caller-supplied callback executor is owned by the caller and may be shut
+     * down before Netty delivers the last frame / close callback — don't let the
+     * rejection propagate into the channel pipeline.
+     */
+    private void dispatch(Runnable task) {
+        try {
+            callbackExecutor.execute(task);
+        } catch (RejectedExecutionException e) {
+            logger.debug("callback dropped, executor already shut down");
         }
     }
 

--- a/karate-core/src/test/resources/io/karatelabs/driver/features/oopif.feature
+++ b/karate-core/src/test/resources/io/karatelabs/driver/features/oopif.feature
@@ -40,3 +40,37 @@ Feature: Out-of-Process Iframe (OOPIF) Support
     * switchFrame(null)
     * def parentValue = script('window.parentValue')
     * match parentValue == 'parent-data'
+
+  @lock=tabs
+  Scenario: Cross-origin iframe reachable after switching tabs
+    # switchPage() drives the tab through a fresh CDP session, and OOPIF
+    # auto-attach is session-scoped — the driver must re-arm it on every
+    # session switch, otherwise cross-origin frames silently stop attaching
+    # and switchFrame fails with "could not find frame". Seen in the wild
+    # with payment-provider card-field iframes on pooled drivers reused
+    # after a scenario that switched or closed tabs.
+    # (also holds the tabs lock: the popup opened here would skew the
+    # page-count assertions in the tab tests if they ran concurrently)
+    * script("window.__popup = window.open('" + crossOriginUrl + "/oopif'), null")
+    * delay(500)
+    * switchPage(crossOriginUrl + '/oopif')
+    * waitFor('#cross-origin-frame')
+    # in this tab the parent is served from the cross-origin host, so the
+    # primary server URL is the "foreign" origin that promotes the iframe
+    # to an OOPIF
+    * script("document.getElementById('cross-origin-frame').src = '" + serverUrl + "/oopif-frame'")
+    * switchFrame('#cross-origin-frame')
+    * def heading = text('h2')
+    * match heading == 'OOPIF Frame Content'
+    * switchFrame(null)
+    # switching back is yet another fresh session — OOPIFs must re-attach
+    # in the original tab too
+    * switchPage(serverUrl + '/oopif')
+    * script("document.getElementById('cross-origin-frame').src = '" + crossOriginUrl + "/oopif-frame'")
+    * switchFrame('#cross-origin-frame')
+    * def frameText = text('#frame-text')
+    * match frameText == 'This content is inside the cross-origin iframe.'
+    * switchFrame(null)
+    # close the popup so later scenarios see a clean slate
+    * script('window.__popup.close(), null')
+    * delay(200)


### PR DESCRIPTION
## Background

We observed UI tests running perfectly under CDP when run individually, but failing when run as part of a full, multi-threaded suite (i.e. re-using an existing browser process / tab) with an error like `Error: could not find frame for locator...`. I fed this basic info into Claude and it identified / implemented this fix 100% autonomously. We're now able to run our full UI test suite without error.

## Description

Target.setAutoAttach is session-scoped, but it was only sent once at driver init, on the root session of the websocket-bound tab. Every activateTarget() call (switchPage, switchPageById, close) attaches to the target through a fresh flattened session and re-enables Page/Runtime there - but never re-armed auto-attach. From that point on, cross-origin iframes (OOPIFs) in the driven tab never fire Target.attachedToTarget, oopifSessions stays empty, and switchFrame() on such an iframe fails with "could not find frame".

This is invisible in single-test runs (fresh driver, root session still armed) but bites pooled drivers in parallel suites: any earlier scenario that switched or closed a tab permanently poisons that driver's OOPIF support for every later scenario. Observed in the wild as payment-provider card-field iframes (zoid/PayPal-style) failing to resolve only when the full suite runs, more often at higher thread counts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [ ] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed
