### PR TITLE
fix(core): callSingle caches only the callee's own variables, fixing Scenario Outline row freeze (#2934)

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/ScenarioRuntime.java
+++ b/karate-core/src/main/java/io/karatelabs/core/ScenarioRuntime.java
@@ -688,7 +688,25 @@ public class ScenarioRuntime implements Callable<ScenarioResult>, KarateJsContex
             }
 
             if (nestedFr.getLastExecuted() != null) {
-                return nestedFr.getLastExecuted().getAllVariables();
+                // Cache only the delta: variables the called feature actually added or
+                // replaced. Returning the callee's full binding set leaks pre-existing
+                // caller vars — notably Scenario Outline example-row vars set during
+                // scenario init — into the Suite-scoped cache, where a cache hit would
+                // overwrite the next row's value (#2934). Mirrors the same fix already
+                // applied to callonce. Identity comparison is intentional: an untouched
+                // inherited binding keeps the same Object reference, while a callee
+                // def/assign produces a new one.
+                Map<String, Object> calleeVars = nestedFr.getLastExecuted().getAllVariables();
+                Map<String, Object> callerVars = getAllVariables();
+                Map<String, Object> delta = new LinkedHashMap<>();
+                for (Map.Entry<String, Object> entry : calleeVars.entrySet()) {
+                    String key = entry.getKey();
+                    Object value = entry.getValue();
+                    if (!callerVars.containsKey(key) || callerVars.get(key) != value) {
+                        delta.put(key, value);
+                    }
+                }
+                return delta;
             }
             return new HashMap<>();
         } else if (content instanceof JavaCallable) {

--- a/karate-core/src/test/java/io/karatelabs/core/callsingle/OutlineFreezeTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/callsingle/OutlineFreezeTest.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Karate Labs Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.karatelabs.core.callsingle;
+
+import io.karatelabs.core.Runner;
+import io.karatelabs.core.SuiteResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduction for issue #2934: in a Scenario Outline whose Background combines
+ * {@code karate.set(karate.callSingle(...))} with a {@code call read(...)}, every outline row
+ * received row 1's Examples values (the per-row scope froze after the first row).
+ */
+class OutlineFreezeTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void outlineRowsKeepOwnValuesWithCallSingleAndCallReadInBackground() throws Exception {
+        Files.writeString(tempDir.resolve("constants.feature"), """
+                @ignore
+                Feature: constants (callSingle target)
+                Scenario:
+                * def serviceName = 'TestService'
+                * def baseUrl = 'https://example.com'
+                """);
+        Files.writeString(tempDir.resolve("bgNoHttpCall.feature"), """
+                @ignore
+                Feature: background call without http
+                Scenario:
+                * def items = [{ id: 'item1' }, { id: 'item2' }]
+                """);
+        Path main = tempDir.resolve("outline.feature");
+        Files.writeString(main, """
+                Feature: outline row values must not freeze
+
+                  Background:
+                    * karate.set( karate.callSingle('constants.feature') )
+                    * def bgResult = call read('bgNoHttpCall.feature')
+
+                  Scenario Outline: Row <rowNum> keeps its own phone
+                    * def expectedPhones = ['1111', '2222', '3333', '4444']
+                    * def phoneStr = phone + ''
+                    * match phoneStr == expectedPhones[__num]
+
+                    Examples:
+                      | rowNum | phone |
+                      | 1      | 1111  |
+                      | 2      | 2222  |
+                      | 3      | 3333  |
+                      | 4      | 4444  |
+                """);
+
+        SuiteResult result = Runner.builder()
+                .path(main.toString())
+                .workingDir(tempDir)
+                .outputConsoleSummary(false)
+                .outputHtmlReport(false)
+                .backupOutputDir(false)
+                .parallel(1);
+
+        assertTrue(
+                result.isPassed(),
+                "each outline row must keep its own Examples values, but a row saw row 1's values");
+    }
+}


### PR DESCRIPTION
## Description

In a Scenario Outline whose `Background` combines `karate.set(karate.callSingle(...))` with a `call read(...)`, every outline row received **row 1's** Examples column values — the per-row scope froze after the first row. Both the `#(col)` placeholders in request bodies and the Examples variable references in assertions resolved to row 1's values, so tests could even false-pass (sent data and expected data both frozen to row 1).

### Root cause

`karate.callSingle()` cached the called feature's **full** final binding set. Because a called feature inherits the caller's visible variables, on row 1 that set included the **current outline row's Examples columns**, and it was deep-copied into the Suite-scoped `callSingle` cache. On rows 2+ the cache hit returned row 1's map (still carrying row 1's columns), and `karate.set(...)` spread it back into scope, overwriting the current row's columns with row 1's values. (Neither keyword alone triggers it: `call read` has no cross-row cache, and `callSingle` without `karate.set` never spreads the stale map back.)

### Why both this and `callonce`

This is the same class of bug already fixed for `callonce` — `StepExecutor.executeCallOnce` snapshots the caller bindings and caches only the callee's delta, with a comment noting that capturing the full binding set *"leaks … Scenario Outline example-row vars set during scenario init … into the cache, where they would overwrite the next row's value on cache hit."* `callSingle` never received the equivalent treatment.

### Fix

`ScenarioRuntime.executeCallSingleInternal` now caches only the **delta** — the variables the called feature actually added or replaced — instead of its full binding set, mirroring the `callonce` fix (identity comparison: an untouched inherited binding keeps the same reference, while a callee `def`/assign produces a new one). A singleton feature's own constants are unaffected; only the echoed caller / outline-row vars are dropped.

## Related Issues

- Fixes #2934

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate

Adds `OutlineFreezeTest` (in the `callsingle` test package) which reproduces the freeze and passes with the fix. Existing `CallSingleTest` (22) and `OutlineTest` (49) continue to pass.