### PR TITLE
fix(report): defer syntax highlighting to on-view

### DIFF
--- a/karate-core/src/main/resources/io/karatelabs/output/karate-feature.html
+++ b/karate-core/src/main/resources/io/karatelabs/output/karate-feature.html
@@ -6,8 +6,9 @@
     <link rel="stylesheet" href="../res/karate-report.css"/>
     <link rel="stylesheet" href="../res/prism-karate.css"/>
     <link rel="icon" href="../res/favicon.ico"/>
-    <!-- data-manual: content is injected by Alpine after load, so we highlight on
-         insert via KarateReport._highlightCode rather than Prism's auto-run. -->
+    <!-- data-manual: content is injected by Alpine after load, and we highlight code
+         blocks lazily on-view (KarateReport._observeCode) rather than Prism's auto-run,
+         so collapsed/off-screen HTTP bodies aren't tokenized until actually shown. -->
     <script src="../res/prism.min.js" data-manual></script>
     <script src="../res/alpine.min.js" defer></script>
     <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('karate-theme') || 'light');</script>

--- a/karate-core/src/main/resources/io/karatelabs/output/res/karate-report.js
+++ b/karate-core/src/main/resources/io/karatelabs/output/res/karate-report.js
@@ -207,6 +207,9 @@ const KarateReport = {
         // A row click shows EVERYTHING — clear any per-kind filter a badge set, so all embeds show.
         detail.querySelectorAll('.k-embed').forEach(el => { el.style.display = ''; });
         delete detail.dataset.kindFilter;
+        // Highlighting is deferred (see initDeferredEmbeds): now that this detail is visible,
+        // colorize its code blocks immediately rather than waiting for the on-view observer.
+        if (!expanded) detail.querySelectorAll('code[class*="language-"]').forEach(el => this._highlightEl(el));
         // The collapsed badges STAY as a persistent handle (they used to be hidden on expand — you then
         // lost track of what the row carried and had nothing to click to collapse). Just clear the
         // per-kind active highlight; the badges remain visible in both states.
@@ -365,8 +368,8 @@ const KarateReport = {
             if (step.logSegments && step.logSegments.length) {
                 // One contiguous <pre> so whitespace stays exactly as logged; code
                 // segments (e.g. JSON bodies) are wrapped in a language-tagged <code>
-                // that Prism colorizes in place (_highlightCode), leaving the request
-                // and header lines around them as plain text.
+                // that Prism colorizes on-view (_observeCode/_highlightEl), leaving the
+                // request and header lines around them as plain text.
                 let inner = '';
                 step.logSegments.forEach(seg => {
                     if (seg.lang) {
@@ -551,12 +554,22 @@ const KarateReport = {
             this._deferIO = new IntersectionObserver(entries => {
                 entries.forEach(e => { if (e.isIntersecting) self._materializeEmbed(e.target); });
             }, { rootMargin: '200px' });
+            // Prism highlighting is deferred the same way embeds are. Highlighting every
+            // code block eagerly at insert time is what makes large feature reports (100s
+            // of scenarios, each with HTTP JSON bodies) explode: Prism turns each body into
+            // thousands of <span> nodes, and 99% of them sit inside collapsed step details
+            // nobody ever opens. Observing instead of highlighting keeps hidden bodies as
+            // plain text until they actually scroll into view / a step is expanded.
+            this._hlIO = new IntersectionObserver(entries => {
+                entries.forEach(e => { if (e.isIntersecting) { self._highlightEl(e.target); self._hlIO.unobserve(e.target); } });
+            }, { rootMargin: '200px' });
         }
         const scan = root => {
             if (root && root.querySelectorAll) {
                 root.querySelectorAll('[data-embed-id][data-defer]').forEach(h => self._observeDeferred(h));
+                root.querySelectorAll('code[class*="language-"]').forEach(el => self._observeCode(el));
             }
-            self._highlightCode(root);
+            if (root && root.matches && root.matches('code[class*="language-"]')) self._observeCode(root);
         };
         if (typeof MutationObserver !== 'undefined' && document.body) {
             new MutationObserver(muts => {
@@ -570,7 +583,28 @@ const KarateReport = {
         scan(document);
         window.addEventListener('beforeprint', () => {
             document.querySelectorAll('[data-embed-id][data-defer]').forEach(h => self._materializeEmbed(h));
+            document.querySelectorAll('code[class*="language-"]').forEach(el => self._highlightEl(el));
         });
+    },
+
+    /**
+     * Register a code block for on-view Prism highlighting via {@link #_hlIO}.
+     * Observing a still-hidden (display:none) block is fine — IntersectionObserver
+     * simply reports it as not-intersecting and fires later, when a step is expanded
+     * or it scrolls into view. Falls back to highlighting immediately when the browser
+     * has no IntersectionObserver.
+     */
+    _observeCode(el) {
+        if (!el || el.dataset.hlDone || el.dataset.hlObserved) return;
+        if (this._hlIO) { el.dataset.hlObserved = '1'; this._hlIO.observe(el); }
+        else this._highlightEl(el);
+    },
+
+    /** Highlight a single code block at most once. */
+    _highlightEl(el) {
+        if (typeof Prism === 'undefined' || !el || el.dataset.hlDone) return;
+        Prism.highlightElement(el);
+        el.dataset.hlDone = '1';
     },
 
     /**
@@ -593,6 +627,7 @@ const KarateReport = {
     },
 
     _deferIO: null,
+    _hlIO: null,
     _deferReady: false,
 
     // Default per-part rendering when no ext claims the embed name — also the


### PR DESCRIPTION
## What

Defer Prism syntax-highlighting in the HTML report so a code block is highlighted only when it becomes visible (its step is expanded or it scrolls into view), instead of highlighting every block eagerly at page load.

Fixes #2938.

## Why

For a feature with many scenarios the feature report becomes extremely slow to open and consumes several GB of browser memory (the issue reports 177 scenarios → ~42 MB page, ~100 s to render, ~6 GB RAM).

Root cause: as Alpine inserts each scenario, `_highlightCode` runs `Prism.highlightElement` on **every** language-tagged `<code>` block immediately — including the large majority that live inside **collapsed** step details the user never opens. Prism turns each JSON body into hundreds of `<span>` nodes (~125 spans/KB), so hundreds of bodies at load produce millions of DOM nodes.

## How

This mirrors the deferral the report **already** uses for embeds (`initDeferredEmbeds` / `IntersectionObserver`):

- A new `_hlIO` `IntersectionObserver` highlights each `<code>` block the first time it becomes visible; blocks are registered via `_observeCode` instead of being highlighted on insert. Observing a still-hidden (`display:none`) block is safe — it simply reports as not-intersecting and fires later, when the step is expanded.
- `toggleStep` highlights the now-visible blocks immediately on expand (no flash of un-colored text).
- `beforeprint` force-highlights everything, so print / PDF / Ctrl-F are unaffected.
- No `IntersectionObserver` support → highlight immediately (previous behavior).

No visual or behavioral change: open a step and its JSON body is pretty-printed and colorized instantly. Only the *timing* of the highlight work changes.

## Measured impact

On a real 177-scenario feature report rendered in Chrome 149, captured at equal render progress:

| | eager (before) | on-view (after) |
|---|---|---|
| Prism token `<span>` nodes at load | 1,891,477 | **0** |
| total `<span>` nodes | 1,944,636 | 53,159 |

(That page contained 317 highlightable JSON bodies totalling ~17.7 MB, all highlighted eagerly before; deferred now.)

## Notes / scope

- This targets the memory blow-up (the dominant cost). Alpine still renders every scenario's step DOM up front, so initial *render time* for a very large feature is a separate concern — out of scope here to keep the change small; scenario virtualization would be a natural follow-up.
- Touches only `res/karate-report.js` and a comment in `karate-feature.html`.

## How to verify

1. Generate a report for a feature with many scenarios / large HTTP bodies; open the feature page — it opens quickly with low memory.
2. Click a step with a response body → JSON appears pretty and syntax-highlighted.
3. Toggle light/dark theme → colors still switch.
4. Print / Ctrl-F → all bodies are highlighted (`beforeprint`).
