### PR TITLE
fix(core): honor docstring as empty RHS for set

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
+++ b/karate-core/src/main/java/io/karatelabs/core/StepExecutor.java
@@ -638,12 +638,17 @@ public class StepExecutor {
         int eqIndex = StepUtils.findAssignmentOperator(text);
         if (eqIndex > 0) {
             String leftPart = text.substring(0, eqIndex).trim();
+            String valueExpr = text.substring(eqIndex + 1).trim();
+            // Handle docstring if expression is empty (docstring IS the RHS expression).
+            if (valueExpr.isEmpty() && step.getDocString() != null) {
+                valueExpr = step.getDocString();
+            }
+
             // Look for "varname /xpath" pattern (space followed by /)
             int spaceSlashIdx = leftPart.indexOf(" /");
             if (spaceSlashIdx > 0) {
                 String varName = leftPart.substring(0, spaceSlashIdx).trim();
                 String xpath = leftPart.substring(spaceSlashIdx + 1).trim();
-                String valueExpr = text.substring(eqIndex + 1).trim();
 
                 Object target = runtime.getVariable(varName);
                 if (target == null) {
@@ -676,7 +681,6 @@ public class StepExecutor {
                 StepUtils.VarAndPath vp = StepUtils.splitVarAndJsonPath(leftPart);
                 Object target = runtime.getVariable(vp.var);
                 if (target instanceof Map || target instanceof List) {
-                    String valueExpr = text.substring(eqIndex + 1).trim();
                     Object value = evalKarateExpression(valueExpr);
                     Json.of(target).set(vp.path, value);
                     return;
@@ -688,7 +692,6 @@ public class StepExecutor {
             // `configure`. Without this, `set foo = { id: #(id) }` fails JS parsing on
             // the `#`. This matches the broader RHS-semantics handling.
             if (StepUtils.isPlainIdentifier(leftPart)) {
-                String valueExpr = text.substring(eqIndex + 1).trim();
                 Object value = evalKarateExpression(valueExpr);
                 runtime.setVariable(leftPart, value);
                 return;

--- a/karate-core/src/test/java/io/karatelabs/core/StepSetRhsTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/StepSetRhsTest.java
@@ -127,4 +127,44 @@ class StepSetRhsTest {
                 """);
         assertPassed(sr);
     }
+
+    @Test
+    void testSetJsonPathWithDocString() {
+        ScenarioRuntime sr = run("""
+                * def v = {}
+                * set v.sub =
+                \"\"\"
+                {a:b}
+                \"\"\"
+                * match v == {sub: {a:b}}
+                """);
+        assertPassed(sr);
+    }
+
+    @Test
+    void testSetFullReplacementWithDocString() {
+        ScenarioRuntime sr = run("""
+                * def foo = { id: 0 }
+                * set foo =
+                \"\"\"
+                { id: 1, name: 'doc' }
+                \"\"\"
+                * match foo == { id: 1, name: 'doc' }
+                """);
+        assertPassed(sr);
+    }
+
+    @Test
+    void testSetJsonPathDocStringWithEmbeddedExpr() {
+        ScenarioRuntime sr = run("""
+                * def id = 42
+                * def foo = { meta: {} }
+                * set foo.meta =
+                \"\"\"
+                { id: #(id), name: 'new' }
+                \"\"\"
+                * match foo.meta == { id: 42, name: 'new' }
+                """);
+        assertPassed(sr);
+    }
 }


### PR DESCRIPTION
## Description

`set` with a multi-line docstring was writing `null` because an empty expression after `=` never picked up the docstring. `def` and `configure` already do this.

```gherkin
* def v = {}
* set v.sub =
  """
  {a:b}
  """
* match v == {sub: {a:b}}
```

## Related Issues

- Fixes #2978

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [ ] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed