### PR TITLE
feat(image): pixelmatch engine with cluster verdict

### DIFF
--- a/karate-image/README.md
+++ b/karate-image/README.md
@@ -16,7 +16,7 @@ image.baselineDir = 'baselines';
 image.optionsDir  = 'baselines';   // where <name>.json tuning files live (defaults to baselineDir)
 image.threshold   = 0.02;          // max % mismatch tolerated
 image.report      = 'mismatched';  // attach diff images: 'all' | 'mismatched' | null
-image.engine      = 'resemble';    // 'resemble' | 'ssim' | 'resemble,ssim' | 'resemble|ssim'
+image.engine      = 'resemble';    // 'resemble' | 'ssim' | 'pixelmatch' | combos: 'resemble,ssim' | 'resemble|pixelmatch'
 ```
 
 Multiple engines: the **smallest** mismatch wins (pass if any engine is within threshold). The
@@ -65,6 +65,67 @@ Baselines resolve at `<baselineDir>/<name>.<ext>` (any ImageIO format; defaults 
 per-name options at `<optionsDir>/<name>.json` — so options can live locally while baselines
 live in, say, S3. Options precedence (low→high): suite/scenario config → `<name>.json` →
 per-call inline.
+
+## The pixelmatch engine
+
+The third engine, `pixelmatch`, is a Java port of
+[mapbox/pixelmatch](https://github.com/mapbox/pixelmatch) v7 (`io.github.t12y:pixelmatch`):
+per-pixel OKLab/HyAB perceptual color difference with built-in anti-aliasing detection.
+Options (per-call, `<name>.json`, all optional):
+
+- `matchingThreshold` (default `0.1`) — per-pixel OKLab HyAB color threshold, 0..1 where
+  black↔white = 1.0; smaller is more sensitive. (Named to avoid clashing with `threshold`,
+  which is the *failure* threshold everywhere in karate-image.)
+- `includeAA` (default `false`) — count anti-aliased pixels as differences.
+- `checkerboard` (default `true`) — blend semi-transparent pixels against a checkerboard
+  pattern (vs plain white) when comparing.
+- `ignoredBoxes` — the same `[{left, right, top, bottom}, …]` boxes (all bounds inclusive)
+  as the resemble/ssim engines; pixels inside are excluded from the comparison entirely,
+  including the cluster verdict's raw and significant counts. Use for dynamic regions
+  (transaction ids, timestamps).
+
+The pixelmatch engine is **count-only**: the diff image in reports is always produced by
+resemble (that is what the HTML lightbox and its live re-diff render), so pixelmatch's own
+diff-rendering options are not exposed. The pixelmatch percentages ride on the `diff()`
+result and the embed `meta` (`pixelmatchMismatchPercentage`, plus the raw/summary/region
+diagnostics when clusters are enabled).
+
+### Cluster verdict (`clusters`)
+
+Pixelmatch-only, **off by default**: a significance layer that separates rendering noise
+(anti-aliasing halos, sub-pixel shifts, font hinting changes between browser versions) from
+real regressions. Enable with `clusters: true` (defaults) or a tuning map:
+
+```js
+image.engine   = 'pixelmatch';
+image.clusters = true;             // suite-wide; or per-call / per-name in <name>.json:
+// { clusters: { coreRadius: 1, minCoreArea: 16, hardDelta: 2.5,
+//               flatness: 0.5, flatFraction: 0.5, minThinArea: 8 } }
+```
+
+With clusters on, the reported `mismatchPercentage` becomes the **significant-diff
+percentage** — pixels in regions classified as real changes (interior mass surviving
+erosion, or thin-but-vivid changes on a flat baseline) — and your existing failure
+`threshold` applies to that. Pure rendering noise reports ~0.0% and passes; a missing
+button reports its true area share. Because noise no longer inflates the number, you can
+tighten `threshold` aggressively (0.01% becomes practical). The raw percentage stays
+visible as `pixelmatchRawMismatchPercentage`, a human-readable `pixelmatchSummary`, and
+per-region boxes in `pixelmatchRegions` (`{x, y, width, height, area, coreArea, meanDelta,
+reason: 'CORE'|'THIN_VIVID'}`) — in both the `diff()` result and the embed `meta`.
+
+| Param | Default | Controls | Raising it | Lowering it |
+|---|---|---|---|---|
+| `coreRadius` | 1 | Max thickness (2r+1 px) treated as potentially noise | Thicker real changes must rely on the safety net; risk of missing small solid changes rises. Use 2 for 2x/retina captures. | (min 1) Thinner noise survives erosion and is counted as significant; false positives return. |
+| `minCoreArea` | 16 | Smallest interior "core" that counts as significant | Small solid changes (icons, single glyphs) may be ignored → false negatives. | Residual noise that survives erosion gets counted → false positives. |
+| `hardDelta` | 2.5 | How vivid a thin change must be for the safety net (× `matchingThreshold`) | Real thin changes (underlines, dividers, recolored text) missed → false negatives. | Strong-ish rendering noise gets rescued as significant → false positives. |
+| `flatness` | 0.5 | How flat the baseline must be under a thin change (× `matchingThreshold`) | More of the baseline qualifies as "flat" → safety net fires more often. | Stricter flatness → thin changes near existing detail are ignored. |
+| `flatFraction` | 0.5 | Share of a thin cluster's pixels that must sit on flat baseline | Thin changes overlapping existing edges (e.g. text recolor) missed. | Noise straddling a flat area may be counted. |
+| `minThinArea` | 8 | Smallest thin cluster the safety net will consider | Small thin marks (a text caret is ~2x16 px) ignored → false negatives. | Isolated vivid speckles (dead pixels, dithering) counted → false positives. |
+
+Notes: `clusters` cannot be combined with ssim's `windowSize` option on the same call when
+both engines run (pixelmatch ignores `windowSize`; it belongs to ssim). The lightbox does
+not yet draw the significant-region boxes on the diff — the coordinates ride on the embed
+`meta` (`pixelmatchRegions`) for when it does.
 
 A runnable, readable walkthrough lives in
 [`src/test/resources/demo/visual-demo.feature`](src/test/resources/demo/visual-demo.feature)

--- a/karate-image/pom.xml
+++ b/karate-image/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>ssim</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.t12y</groupId>
+            <artifactId>pixelmatch</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/karate-image/src/main/java/io/karatelabs/ext/image/ImageApi.java
+++ b/karate-image/src/main/java/io/karatelabs/ext/image/ImageApi.java
@@ -179,6 +179,18 @@ public class ImageApi implements SimpleObject {
         if (r.containsKey(ImageComparison.SSIM_MISMATCH_PERCENT)) {
             out.put("ssimMismatchPercentage", num(r.get(ImageComparison.SSIM_MISMATCH_PERCENT)));
         }
+        if (r.containsKey(ImageComparison.PIXELMATCH_MISMATCH_PERCENT)) {
+            out.put("pixelmatchMismatchPercentage", num(r.get(ImageComparison.PIXELMATCH_MISMATCH_PERCENT)));
+        }
+        if (r.containsKey(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT)) {
+            out.put("pixelmatchRawMismatchPercentage", num(r.get(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT)));
+        }
+        if (r.containsKey(ImageComparison.PIXELMATCH_SUMMARY)) {
+            out.put("pixelmatchSummary", str(r.get(ImageComparison.PIXELMATCH_SUMMARY)));
+        }
+        if (r.containsKey(ImageComparison.PIXELMATCH_REGIONS)) {
+            out.put("pixelmatchRegions", r.get(ImageComparison.PIXELMATCH_REGIONS));
+        }
         out.put("mismatch", mismatch);
         out.put("scaleMismatch", scaleMismatch);
         out.put("threshold", threshold);
@@ -236,6 +248,19 @@ public class ImageApi implements SimpleObject {
         }
         if (r.containsKey(ImageComparison.SSIM_MISMATCH_PERCENT)) {
             meta.put("ssimMismatchPercentage", num(r.get(ImageComparison.SSIM_MISMATCH_PERCENT)));
+        }
+        if (r.containsKey(ImageComparison.PIXELMATCH_MISMATCH_PERCENT)) {
+            meta.put("pixelmatchMismatchPercentage", num(r.get(ImageComparison.PIXELMATCH_MISMATCH_PERCENT)));
+        }
+        if (r.containsKey(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT)) {
+            meta.put("pixelmatchRawMismatchPercentage", num(r.get(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT)));
+        }
+        if (r.containsKey(ImageComparison.PIXELMATCH_SUMMARY)) {
+            meta.put("pixelmatchSummary", str(r.get(ImageComparison.PIXELMATCH_SUMMARY)));
+        }
+        // significant-region bounding boxes; TODO draw them on the diff in the lightbox
+        if (r.containsKey(ImageComparison.PIXELMATCH_REGIONS)) {
+            meta.put("pixelmatchRegions", r.get(ImageComparison.PIXELMATCH_REGIONS));
         }
         meta.put("threshold", num(r.get("failureThreshold")));
         meta.put("defaultThreshold", num(r.get("defaultFailureThreshold")));
@@ -375,6 +400,9 @@ public class ImageApi implements SimpleObject {
         d.put("report", config.getOrDefault("report", "mismatched"));
         if (config.containsKey("allowScaling")) {
             d.put("allowScaling", config.get("allowScaling"));
+        }
+        if (config.containsKey("clusters")) {
+            d.put("clusters", config.get("clusters"));
         }
         return d;
     }

--- a/karate-image/src/main/java/io/karatelabs/ext/image/ImageComparison.java
+++ b/karate-image/src/main/java/io/karatelabs/ext/image/ImageComparison.java
@@ -23,6 +23,9 @@
  */
 package io.karatelabs.ext.image;
 
+import io.github.t12y.pixelmatch.ClusterAnalysis;
+import io.github.t12y.pixelmatch.ClusterOptions;
+import io.github.t12y.pixelmatch.Pixelmatch;
 import io.github.t12y.resemble.ErrorType;
 import io.github.t12y.resemble.Resemble;
 import io.github.t12y.resemble.Result;
@@ -43,9 +46,9 @@ import static io.github.t12y.ssim.SSIM.ssim;
 
 /**
  * Server-side pixel-diff engine for the image-comparison ext. Reads a baseline +
- * latest PNG/JPEG, runs the resemble and/or ssim engine over the unpacked RGBA
- * pixels, and returns a result map carrying the mismatch percentage and (when a
- * report is requested) the baseline / latest / diff {@link BufferedImage}s.
+ * latest PNG/JPEG, runs the resemble, ssim and/or pixelmatch engine over the
+ * unpacked RGBA pixels, and returns a result map carrying the mismatch percentage
+ * and (when a report is requested) the baseline / latest / diff {@link BufferedImage}s.
  * <p>
  * The pixel-comparison logic was contributed by jkeys089 (github.com/jkeys089),
  * who also authors the underlying {@code io.github.t12y:resemble} / {@code :ssim}
@@ -56,11 +59,18 @@ public class ImageComparison {
 
     public static final String RESEMBLE = "resemble";
     public static final String SSIM = "ssim";
+    public static final String PIXELMATCH = "pixelmatch";
     public static final String BASELINE_IMAGE = "baselineImage";
     public static final String LATEST_IMAGE = "latestImage";
     public static final String DIFF_IMAGE = "diffImage";
     public static final String RESEMBLE_MISMATCH_PERCENT = "resembleMismatchPercentage";
     public static final String SSIM_MISMATCH_PERCENT = "ssimMismatchPercentage";
+    public static final String PIXELMATCH_MISMATCH_PERCENT = "pixelmatchMismatchPercentage";
+    // present only when the cluster verdict is enabled: the raw (unfiltered) percentage
+    // stays visible as a diagnostic alongside the significant one that drives pass/fail
+    public static final String PIXELMATCH_RAW_MISMATCH_PERCENT = "pixelmatchRawMismatchPercentage";
+    public static final String PIXELMATCH_SUMMARY = "pixelmatchSummary";
+    public static final String PIXELMATCH_REGIONS = "pixelmatchRegions";
 
     private static final String[] IGNORED_BOX_KEYS = new String[]{"left", "right", "top", "bottom"};
     private static final String[] IGNORED_COLOR_KEYS = new String[]{"r", "g", "b"};
@@ -79,6 +89,7 @@ public class ImageComparison {
     private boolean includeDiffImageOnSuccess;
     private boolean includeDiffImageOnFailure;
     private String[] engines;
+    private Object clustersConfig;
     private final Map<String, Object> options;
     private final Map<String, Object> result;
 
@@ -172,6 +183,9 @@ public class ImageComparison {
             engines = engineConfig.split(",");
         }
 
+        // per-call/name.json options win over the suite-wide default (same precedence as engine)
+        clustersConfig = options.containsKey("clusters") ? options.get("clusters") : defaultOptions.get("clusters");
+
         String reportFormat = asString(defaultOptions.get("report"));
         if ("all".equalsIgnoreCase(reportFormat)) {
             includeDiffImageOnSuccess = true;
@@ -208,6 +222,9 @@ public class ImageComparison {
                     break;
                 case SSIM:
                     currentMismatchPercentage = imageComparison.execSSIM();
+                    break;
+                case PIXELMATCH:
+                    currentMismatchPercentage = imageComparison.execPixelmatch();
                     break;
                 default:
                     logger.error("skipping unsupported image comparison engine: {}", engine);
@@ -270,6 +287,78 @@ public class ImageComparison {
         result.put(SSIM_MISMATCH_PERCENT, mismatchPercentage);
 
         return mismatchPercentage;
+    }
+
+    private double execPixelmatch() {
+        io.github.t12y.pixelmatch.Options opts = pixelmatchOptions();
+
+        // pixelmatch is count-only: the diff image is always resemble's, which is what the
+        // HTML report lightbox (and its client-side live re-diff) renders. checkMismatch
+        // runs the resemble engine whenever a diff image is needed and none exists yet.
+        double mismatchPercentage;
+        if (opts.clusters != null) {
+            // cluster verdict: the significant-diff percentage drives pass/fail; rendering
+            // noise (AA halos, sub-pixel shifts) reports as ~0. Raw numbers stay visible.
+            ClusterAnalysis analysis = Pixelmatch.analyze(baselinePixels, latestPixels, null, width, height, opts);
+            mismatchPercentage = analysis.significantPercentage;
+            result.put(PIXELMATCH_RAW_MISMATCH_PERCENT, analysis.rawPercentage);
+            result.put(PIXELMATCH_SUMMARY, analysis.summary());
+            result.put(PIXELMATCH_REGIONS, regionMaps(analysis));
+        } else {
+            int mismatched = Pixelmatch.pixelmatch(baselinePixels, latestPixels, null, width, height, opts);
+            mismatchPercentage = 100.0 * mismatched / (width * height);
+        }
+
+        result.put(PIXELMATCH_MISMATCH_PERCENT, mismatchPercentage);
+        return mismatchPercentage;
+    }
+
+    private static List<Map<String, Object>> regionMaps(ClusterAnalysis analysis) {
+        List<Map<String, Object>> regions = new ArrayList<>();
+        for (ClusterAnalysis.Region region : analysis.significantRegions) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("x", region.x);
+            m.put("y", region.y);
+            m.put("width", region.width);
+            m.put("height", region.height);
+            m.put("area", region.area);
+            m.put("coreArea", region.coreArea);
+            m.put("meanDelta", region.meanDelta);
+            m.put("reason", region.reason.name());
+            regions.add(m);
+        }
+        return regions;
+    }
+
+    private io.github.t12y.pixelmatch.Options pixelmatchOptions() {
+        io.github.t12y.pixelmatch.Options opts = io.github.t12y.pixelmatch.Options.defaults();
+
+        // 'threshold' already means the failure threshold throughout karate-image,
+        // so the per-pixel OKLab HyAB matching threshold gets its own key.
+        // (pixelmatch's diff-rendering options are not exposed: it never draws here)
+        opts.threshold = getDouble("matchingThreshold", opts.threshold);
+        opts.includeAA = getBool("includeAA", opts.includeAA);
+        opts.checkerboard = getBool("checkerboard", opts.checkerboard);
+        opts.ignoredBoxes = getIgnoredBoxes();
+        opts.clusters = clusterOptions();
+
+        return opts;
+    }
+
+    /** {@code clusters: true} enables the verdict with defaults; a map tunes it; absent/false/null disables. */
+    private ClusterOptions clusterOptions() {
+        if (clustersConfig instanceof Map) {
+            Map cfg = (Map) clustersConfig;
+            ClusterOptions clusters = ClusterOptions.defaults();
+            clusters.coreRadius = toInt(cfg.get("coreRadius"), clusters.coreRadius);
+            clusters.minCoreArea = toInt(cfg.get("minCoreArea"), clusters.minCoreArea);
+            clusters.hardDelta = toDouble(cfg.get("hardDelta"), clusters.hardDelta);
+            clusters.flatness = toDouble(cfg.get("flatness"), clusters.flatness);
+            clusters.flatFraction = toDouble(cfg.get("flatFraction"), clusters.flatFraction);
+            clusters.minThinArea = toInt(cfg.get("minThinArea"), clusters.minThinArea);
+            return clusters;
+        }
+        return toBool(clustersConfig) ? ClusterOptions.defaults() : null;
     }
 
     private io.github.t12y.resemble.Options resembleOptions() {
@@ -373,11 +462,14 @@ public class ImageComparison {
     }
 
     private int getInt(String name, int defaultValue) {
-        Object val = options.get(name);
-        if (!(val instanceof Number)) {
+        return toInt(options.get(name), defaultValue);
+    }
+
+    private static int toInt(Object obj, int defaultValue) {
+        if (!(obj instanceof Number)) {
             return defaultValue;
         }
-        return ((Number) val).intValue();
+        return ((Number) obj).intValue();
     }
 
     private String getString(String name, String defaultValue) {

--- a/karate-image/src/test/java/io/karatelabs/ext/image/ImageComparisonTest.java
+++ b/karate-image/src/test/java/io/karatelabs/ext/image/ImageComparisonTest.java
@@ -69,7 +69,7 @@ class ImageComparisonTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"resemble", "ssim"})
+    @ValueSource(strings = {"resemble", "ssim", "pixelmatch"})
     void testIgnoredBoxes(String engine) {
         Map<String, Integer> box = new HashMap<>();
         box.put("left", 1);

--- a/karate-image/src/test/java/io/karatelabs/ext/image/ImageExtE2ETest.java
+++ b/karate-image/src/test/java/io/karatelabs/ext/image/ImageExtE2ETest.java
@@ -54,6 +54,55 @@ class ImageExtE2ETest {
     Path tempDir;
 
     @Test
+    void reportModeGatesEmbedsByVerdict() throws Exception {
+        Files.writeString(tempDir.resolve("karate-boot.js"), """
+            const image = boot.ext('image');
+            image.report = 'mismatched';
+            image.threshold = 0.1;
+            // no ssim: its default 11x11 window degenerates to ~0% difference on the
+            // tiny 3x3 fixtures here, short-circuiting the fallback chain
+            image.engine = 'resemble|pixelmatch';
+            image.clusters = true;
+            """);
+
+        Path feature = tempDir.resolve("report-mode.feature");
+        Files.writeString(feature, """
+            Feature: report mode gates embeds
+
+            Scenario: mismatched report omits passing embeds entirely
+            * def blue = new Uint8Array(java.util.Base64.getDecoder().decode('%s'))
+            * def green = new Uint8Array(java.util.Base64.getDecoder().decode('%s'))
+
+            # passing comparison: no embed, hence nothing for the HTML/PDF reports
+            * def passing = image.diff({ baseline: blue, latest: blue })
+            * match passing.pass == true
+            * match passing.embed == null
+
+            # failing comparison (clusters off per-call: a single changed pixel is below
+            # minThinArea, so the suite-wide verdict would classify it as noise and pass)
+            * def failing = image.diff({ baseline: blue, latest: green, clusters: false })
+            * match failing.pass == false
+            * match failing.embed == '#notnull'
+
+            # report=all embeds passing comparisons too, diff image included
+            * image.report = 'all'
+            * def passingAll = image.diff({ baseline: blue, latest: blue })
+            * match passingAll.pass == true
+            * match passingAll.embed == '#notnull'
+            * match passingAll.embed.parts == '#[3]'
+            """.formatted(BLUE, GREEN));
+
+        SuiteResult result = Runner.path(feature.toString())
+                .workingDir(tempDir)
+                .outputDir(tempDir.resolve("reports"))
+                .outputConsoleSummary(false)
+                .parallel(1);
+
+        assertEquals(1, result.getScenarioPassedCount(), "report-mode scenario should pass");
+        assertEquals(0, result.getScenarioFailedCount());
+    }
+
+    @Test
     void establishMatchAndMismatch() throws Exception {
         Path baselineDir = tempDir.resolve("baselines");
         Files.writeString(tempDir.resolve("karate-boot.js"), """

--- a/karate-image/src/test/java/io/karatelabs/ext/image/PixelmatchEngineTest.java
+++ b/karate-image/src/test/java/io/karatelabs/ext/image/PixelmatchEngineTest.java
@@ -1,0 +1,272 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 Karate Labs Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.karatelabs.ext.image;
+
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PixelmatchEngineTest {
+
+    private static final int WHITE = 0xFFFFFFFF;
+    private static final int BLACK = 0xFF000000;
+    private static final int BLUE = 0xFF0000FF;
+    private static final int GREEN = 0xFF00FF00;
+    private static final int RED = 0xFFFF0000;
+
+    private static Map<String, Object> opts(Object... params) {
+        Map<String, Object> options = new HashMap<>();
+        for (int i = 0; i < params.length; i += 2) {
+            options.put(params[i].toString(), params[i + 1]);
+        }
+        return options;
+    }
+
+    private static double round(double d) {
+        return Math.round(d * 100.0) / 100.0;
+    }
+
+    private static BufferedImage image(int w, int h, int rgb) {
+        BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        fill(img, 0, 0, w, h, rgb);
+        return img;
+    }
+
+    private static void fill(BufferedImage img, int x, int y, int w, int h, int rgb) {
+        for (int yy = y; yy < y + h; yy++) {
+            for (int xx = x; xx < x + w; xx++) {
+                img.setRGB(xx, yy, rgb);
+            }
+        }
+    }
+
+    private static byte[] png(BufferedImage img) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(img, "png", baos);
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // blue 3x3 square; latest has a green center pixel
+    private static byte[] blueSquare() {
+        return png(image(3, 3, BLUE));
+    }
+
+    private static byte[] blueSquareGreenCenter() {
+        BufferedImage img = image(3, 3, BLUE);
+        img.setRGB(1, 1, GREEN);
+        return png(img);
+    }
+
+    @Test
+    void testBasicMismatchPercentage() {
+        Map<String, Object> result = ImageComparison.run(
+                blueSquare(), blueSquareGreenCenter(), opts(), opts("engine", "pixelmatch"));
+
+        // 3x3 = 9 pixels, 1 is different => ~11.11%
+        assertEquals(11.11, round((double) result.get("mismatchPercentage")));
+        assertEquals(11.11, round((double) result.get(ImageComparison.PIXELMATCH_MISMATCH_PERCENT)));
+        assertEquals(Boolean.TRUE, result.get("isMismatch"));
+        // no clusters => no raw/summary diagnostics
+        assertFalse(result.containsKey(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT));
+    }
+
+    @Test
+    void testMatchingThreshold() {
+        // black vs near-black rgb(13,13,13): below the default OKLab matching threshold
+        // (toe correction), but a diff when the matching threshold is turned way down
+        byte[] black = png(image(1, 1, BLACK));
+        byte[] nearBlack = png(image(1, 1, 0xFF0D0D0D));
+
+        Map<String, Object> below = ImageComparison.run(
+                black, nearBlack, opts(), opts("engine", "pixelmatch"));
+        assertEquals(0.0, below.get("mismatchPercentage"));
+
+        Map<String, Object> above = ImageComparison.run(
+                black, nearBlack, opts("matchingThreshold", 0.001), opts("engine", "pixelmatch"));
+        assertEquals(100.0, above.get("mismatchPercentage"));
+    }
+
+    @Test
+    void testClustersIgnoreShiftedDivider() {
+        // a 1px black divider moves down one row: classic rendering noise. Raw diff is
+        // 2% of the image; the cluster verdict reports 0 significant and the step passes.
+        BufferedImage baseline = image(200, 100, WHITE);
+        fill(baseline, 0, 50, 200, 1, BLACK);
+        BufferedImage latest = image(200, 100, WHITE);
+        fill(latest, 0, 51, 200, 1, BLACK);
+
+        Map<String, Object> result = ImageComparison.run(
+                png(baseline), png(latest), opts("clusters", true), opts("engine", "pixelmatch"));
+
+        assertEquals(0.0, result.get("mismatchPercentage"));
+        assertNull(result.get("isMismatch"));
+        assertEquals(2.0, round((double) result.get(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT)));
+        assertTrue(((String) result.get(ImageComparison.PIXELMATCH_SUMMARY)).contains("rendering noise"));
+        assertTrue(((List<?>) result.get(ImageComparison.PIXELMATCH_REGIONS)).isEmpty());
+    }
+
+    @Test
+    void testClustersCatchRealChange() {
+        BufferedImage baseline = image(200, 200, WHITE);
+        BufferedImage latest = image(200, 200, WHITE);
+        fill(latest, 90, 90, 20, 20, RED);
+
+        Map<String, Object> result = ImageComparison.run(
+                png(baseline), png(latest), opts("clusters", true), opts("engine", "pixelmatch"));
+
+        // 400 significant pixels of 40000 = 1%
+        assertEquals(1.0, result.get("mismatchPercentage"));
+        assertEquals(Boolean.TRUE, result.get("isMismatch"));
+
+        List<Map<String, Object>> regions = (List<Map<String, Object>>) result.get(ImageComparison.PIXELMATCH_REGIONS);
+        assertEquals(1, regions.size());
+        assertEquals("CORE", regions.get(0).get("reason"));
+        assertEquals(90, regions.get(0).get("x"));
+        assertEquals(90, regions.get(0).get("y"));
+        assertEquals(20, regions.get(0).get("width"));
+        assertEquals(20, regions.get(0).get("height"));
+    }
+
+    @Test
+    void testClustersTuningMap() {
+        // a single changed pixel is noise under the defaults (below minThinArea)...
+        Map<String, Object> defaults = ImageComparison.run(
+                blueSquare(), blueSquareGreenCenter(), opts("clusters", true), opts("engine", "pixelmatch"));
+        assertEquals(0.0, defaults.get("mismatchPercentage"));
+
+        // ...but a tuned minThinArea lets the vivid-on-flat safety net rescue it
+        Map<String, Object> tuned = ImageComparison.run(
+                blueSquare(), blueSquareGreenCenter(),
+                opts("clusters", opts("minThinArea", 1)), opts("engine", "pixelmatch"));
+        assertEquals(11.11, round((double) tuned.get("mismatchPercentage")));
+
+        List<Map<String, Object>> regions = (List<Map<String, Object>>) tuned.get(ImageComparison.PIXELMATCH_REGIONS);
+        assertEquals(1, regions.size());
+        assertEquals("THIN_VIVID", regions.get(0).get("reason"));
+    }
+
+    @Test
+    void testClustersSuiteWideDefaultAndPerCallOverride() {
+        BufferedImage baseline = image(200, 100, WHITE);
+        fill(baseline, 0, 50, 200, 1, BLACK);
+        BufferedImage latest = image(200, 100, WHITE);
+        fill(latest, 0, 51, 200, 1, BLACK);
+        byte[] baselinePng = png(baseline);
+        byte[] latestPng = png(latest);
+
+        // suite-wide default (defaultOptions) enables the verdict
+        Map<String, Object> suiteWide = ImageComparison.run(
+                baselinePng, latestPng, opts(), opts("engine", "pixelmatch", "clusters", true));
+        assertEquals(0.0, suiteWide.get("mismatchPercentage"));
+
+        // per-call clusters=false wins over the suite-wide default
+        Map<String, Object> overridden = ImageComparison.run(
+                baselinePng, latestPng, opts("clusters", false), opts("engine", "pixelmatch", "clusters", true));
+        assertEquals(2.0, round((double) overridden.get("mismatchPercentage")));
+        assertFalse(overridden.containsKey(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT));
+    }
+
+    @Test
+    void testDiffImageIsAlwaysResembles() {
+        // pixelmatch never draws: when a report wants a diff image, the resemble engine
+        // produces it (that is what the HTML lightbox and its live re-diff render)
+        Map<String, Object> result = ImageComparison.run(
+                blueSquare(), blueSquareGreenCenter(), opts(), opts("engine", "pixelmatch", "report", "all"));
+
+        BufferedImage diff = (BufferedImage) result.get(ImageComparison.DIFF_IMAGE);
+        assertNotNull(diff);
+        assertEquals(3, diff.getWidth());
+        assertEquals(3, diff.getHeight());
+        // resemble's default error pixel color (pink), not pixelmatch's red
+        assertEquals(0xFFFF00FF, diff.getRGB(1, 1));
+        // the resemble fallback also surfaces its percentage for the reports
+        assertTrue(result.containsKey(ImageComparison.RESEMBLE_MISMATCH_PERCENT));
+        // ...but pass/fail still used pixelmatch's number (the only engine in the list)
+        assertEquals(11.11, round((double) result.get("mismatchPercentage")));
+    }
+
+    @Test
+    void testEngineComboKeepsResembleDiffImage() {
+        Map<String, Object> result = ImageComparison.run(
+                blueSquare(), blueSquareGreenCenter(), opts(), opts("engine", "resemble,pixelmatch", "report", "all"));
+
+        BufferedImage diff = (BufferedImage) result.get(ImageComparison.DIFF_IMAGE);
+        assertNotNull(diff);
+        assertEquals(0xFFFF00FF, diff.getRGB(1, 1)); // resemble's diff, not overwritten
+    }
+
+    @Test
+    void testNoReportNoDiffImage() {
+        Map<String, Object> result = ImageComparison.run(
+                blueSquare(), blueSquareGreenCenter(), opts(), opts("engine", "pixelmatch"));
+        assertNull(result.get(ImageComparison.DIFF_IMAGE));
+    }
+
+    @Test
+    void testIgnoredBoxesWithClusters() {
+        // a real change inside an ignored box (e.g. a dynamic transaction id) contributes
+        // nothing - not even to the raw diagnostic
+        BufferedImage baseline = image(200, 200, WHITE);
+        BufferedImage latest = image(200, 200, WHITE);
+        fill(latest, 90, 90, 20, 20, RED);
+
+        Map<String, Object> box = new HashMap<>();
+        box.put("left", 90);
+        box.put("right", 109);
+        box.put("top", 90);
+        box.put("bottom", 109);
+
+        Map<String, Object> result = ImageComparison.run(
+                png(baseline), png(latest),
+                opts("clusters", true, "ignoredBoxes", List.of(box)),
+                opts("engine", "pixelmatch"));
+
+        assertEquals(0.0, result.get("mismatchPercentage"));
+        assertEquals(0.0, result.get(ImageComparison.PIXELMATCH_RAW_MISMATCH_PERCENT));
+        assertNull(result.get("isMismatch"));
+    }
+
+    @Test
+    void testEngineCombination() {
+        byte[] img = blueSquare();
+        Map<String, Object> result = ImageComparison.run(
+                img, img, opts(), opts("engine", "pixelmatch,resemble"));
+
+        assertEquals(0.0, result.get("mismatchPercentage"));
+        assertTrue(result.containsKey(ImageComparison.PIXELMATCH_MISMATCH_PERCENT));
+        assertTrue(result.containsKey(ImageComparison.RESEMBLE_MISMATCH_PERCENT));
+    }
+}


### PR DESCRIPTION
## Description

Add a new `pixelmatch` image comparison engine. This is a direct java port of https://github.com/mapbox/pixelmatch which has superior antialiasing and perceptual color difference.

In addition to the base pixelmatch functionality, we've also added a new "cluster verdict" feature inspired by [Honeydiff](https://vizzly.dev/blog/honeydiff-fast-image-diffing-foundation/) that dynamically "erodes" insignificant diff noise introduced by the rendering pipeline. In other words, if you often see comparison failures with faint / spotty / wispy diffs when you make a change to your pipeline (e.g. upgrade browser versions) this new engine will help reduce false positives by removing the noise from the diff percentage calculation while still catching true / significant differences.

The new engine is fully backward compatible and supports existing `ignoredBoxes`.

You can enable it next to existing engines like:
```js
// as a fallback
image.engine = 'resemble|ssim|pixelmatch'
// or always run
image.engine = 'resemble,ssim,pixelmatch'

// cluster verdict is opt-in
image.clusters = true
// or customize behavior
image.clusters = { ... }
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [ ] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [x] I have updated documentation as needed