### PR TITLE
Fix #2977: don't parse text/plain response body as JSON when it starts with [ or {

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/http/HttpUtils.java
+++ b/karate-core/src/main/java/io/karatelabs/http/HttpUtils.java
@@ -204,6 +204,9 @@ public class HttpUtils {
         switch (trimmed.charAt(0)) {
             case '{':
             case '[':
+                if (resourceType != null && resourceType.isText() && !resourceType.isJson()) {
+                    return raw;
+                }
                 if (strict) {
                     return Json.parseStrict(raw);
                 }

--- a/karate-core/src/test/java/io/karatelabs/http/contenttype/ContentTypeTest.java
+++ b/karate-core/src/test/java/io/karatelabs/http/contenttype/ContentTypeTest.java
@@ -1,0 +1,42 @@
+package io.karatelabs.http.contenttype;
+
+import io.karatelabs.core.MockServer;
+import io.karatelabs.core.Runner;
+import io.karatelabs.core.SuiteResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for issue #2977: a response with Content-Type
+ * "text/plain;charset=UTF-8" whose body happens to start with '[' or '{'
+ * (e.g. a TOML document) must NOT be auto-parsed as JSON.
+ */
+class ContentTypeTest {
+
+    private static MockServer mockServer;
+
+    @BeforeAll
+    static void startMockServer() {
+        mockServer = MockServer.feature("classpath:io/karatelabs/http/contenttype/mock-server.feature").start();
+    }
+
+    @AfterAll
+    static void stopMockServer() {
+        if (mockServer != null) {
+            mockServer.stopAndWait();
+        }
+    }
+
+    @Test
+    void testTextPlainBodyStartingWithBracketIsNotParsedAsJson() {
+        SuiteResult result = Runner.path("classpath:io/karatelabs/http/contenttype/content-type.feature")
+                .systemProperty("server.port", mockServer.getPort() + "")
+                .outputHtmlReport(false)
+                .outputConsoleSummary(false)
+                .parallel(1);
+        assertEquals(0, result.getScenarioFailedCount(), String.join("\n", result.getErrors()));
+    }
+}

--- a/karate-core/src/test/resources/io/karatelabs/http/contenttype/content-type.feature
+++ b/karate-core/src/test/resources/io/karatelabs/http/contenttype/content-type.feature
@@ -1,0 +1,8 @@
+Feature: content-type text/plain not misparsed as JSON
+
+  Scenario: response body starting with '[' but Content-Type text/plain stays a string
+    Given url 'http://localhost:' + karate.properties['server.port'] + '/config'
+    When method GET
+    Then status 200
+    * match typeof response == 'string'
+    * match response contains 'round_interval'

--- a/karate-core/src/test/resources/io/karatelabs/http/contenttype/mock-server.feature
+++ b/karate-core/src/test/resources/io/karatelabs/http/contenttype/mock-server.feature
@@ -1,0 +1,5 @@
+Feature: Mock API returning text/plain;charset=UTF-8
+
+  Scenario: pathMatches('/config') && methodIs('get')
+    * def responseStatus = 200
+    * string response = "[agent]\n\tinterval = \"1s\"\n\tround_interval = true\n\n[[processors.date]]\n\torder=1"


### PR DESCRIPTION
Fixes #2977

## Problem
A response body with `Content-Type: text/plain;charset=UTF-8` was being
incorrectly auto-parsed as JSON if the body happened to start with `[`
or `{` — for example, a TOML document whose top-level table header is
`[agent]`. Karate would return a JSON-parsed result (or single-char
array) instead of the raw string.

## Root cause
In `HttpUtils.fromString()`, the switch on the first character of the
response body has separate branches for JSON (`{`/`[`) and XML (`<`).
The XML branch already checks `resourceType` before attempting to
parse (`resourceType == null || resourceType.isXml() || resourceType.isText()`),
but the JSON branch had no equivalent check — it unconditionally tried
to parse anything starting with `{` or `[` as JSON, ignoring the
actual resolved `Content-Type`.

## Fix
Added a guard mirroring the existing XML branch's pattern: if
`resourceType` is explicitly `TEXT` (and not `JSON`), skip JSON parsing
and return the raw string.

## Testing
Added `ContentTypeTest` with a mock server reproducing the exact
scenario from the issue (TOML-like body served with
`text/plain;charset=UTF-8`). Verified the test fails without the fix
and passes with it.