### PR TITLE
fix(core): treat Office binary extensions as bytes in read()

### DIFF
--- a/karate-core/src/main/java/io/karatelabs/core/KarateJs.java
+++ b/karate-core/src/main/java/io/karatelabs/core/KarateJs.java
@@ -244,7 +244,8 @@ public class KarateJs extends KarateJsBase implements PerfContext {
                 case "csv" -> DataUtils.fromCsv(resource.getText());
                 case "yml", "yaml" -> DataUtils.fromYaml(resource.getText());
                 // Binary file types - return raw bytes (V1 compatibility)
-                case "pdf", "png", "jpg", "jpeg", "gif", "ico", "mp4", "bin", "zip", "gz", "tar" -> FileUtils.toBytes(resource.getStream());
+                case "pdf", "png", "jpg", "jpeg", "gif", "ico", "mp4", "bin", "zip", "gz", "tar",
+                     "xlsx", "xls", "docx", "doc", "pptx", "ppt" -> FileUtils.toBytes(resource.getStream());
                 default -> resource.getText();
             };
         };

--- a/karate-core/src/test/java/io/karatelabs/core/KarateJsTest.java
+++ b/karate-core/src/test/java/io/karatelabs/core/KarateJsTest.java
@@ -5,8 +5,11 @@ import io.karatelabs.common.Resource;
 import io.karatelabs.http.ErrorHttpClient;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,6 +88,20 @@ class KarateJsTest {
         Object p = context.engine.get("p");
         assertTrue(p instanceof String && !"fallback".equals(p),
                 "real env var should win over default");
+    }
+
+    @Test
+    void testReadOfficeBinaryExtensions() throws Exception {
+        KarateJs context = new KarateJs(Resource.path("src/test/resources"));
+        Path xlsx = Path.of("src/test/resources/io/karatelabs/core/upload/test.xlsx");
+        byte[] expected = Files.readAllBytes(xlsx);
+
+        context.engine.eval("""
+                var bytes = read('io/karatelabs/core/upload/test.xlsx');
+                var type = karate.typeOf(bytes);
+                """);
+        assertEquals("bytes", context.engine.get("type"));
+        assertArrayEquals(expected, (byte[]) context.engine.get("bytes"));
     }
 
     @Test


### PR DESCRIPTION
## Description

`karate.read()` uses a hardcoded extension allowlist to decide whether a file is returned as raw bytes or decoded text. Office formats (`.xlsx`, `.xls`, `.docx`, `.doc`, `.pptx`, `.ppt`) are ZIP-based binaries but were missing from that list, so they fell through to `resource.getText()` — silently corrupting the bytes.

This PR extends the binary allowlist so those extensions return `byte[]`, matching the documented behavior and V1 compatibility intent.

## Related Issues

- Fixes #3021

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Test improvement
- [ ] Documentation update

## Checklist

- [ ] I have discussed this change with the project maintainers
- [x] Tests pass locally (`mvn test`)
- [x] I have added or updated tests as appropriate
- [ ] I have updated documentation as needed

## Test plan

- [x] `KarateJsTest.testReadOfficeBinaryExtensions` — asserts `read('…/test.xlsx')` returns `bytes` and matches file on disk byte-for-byte
- [x] `KarateJsTest` (9 tests) — all pass
- [x] `UploadE2eTest` (21 tests) — regression check for existing xlsx upload paths

## Prove-it

**Before (HEAD):** `KarateJsTest.testReadOfficeBinaryExtensions` fails with `expected: <bytes> but was: <string>` — `.xlsx` decoded as lossy text.

**After:** same test passes; `assertArrayEquals` confirms byte-for-byte identity with source file (PK zip magic preserved).